### PR TITLE
feat: add Discord PR review reminder workflow

### DIFF
--- a/.github/workflows/discord-review-reminder.yml
+++ b/.github/workflows/discord-review-reminder.yml
@@ -91,8 +91,7 @@ jobs:
             let messageCount = 0;
             let skippedCount = 0;
             const failures = [];
-            const reminderEmbeds = [];
-            const allowedUserIds = new Set();
+            const reminders = [];
 
             for (const pr of pulls) {
               if (pr.draft) {
@@ -118,13 +117,9 @@ jobs:
                 const discordId = userMap[user.login];
                 return discordId ? `<@${discordId}>` : `@${user.login}`;
               });
-
-              for (const user of users) {
-                const discordId = userMap[user.login];
-                if (discordId) {
-                  allowedUserIds.add(discordId);
-                }
-              }
+              const mappedUserIds = users
+                .map((user) => userMap[user.login])
+                .filter(Boolean);
 
               const pendingReviewerParts = [...userMentions];
 
@@ -135,29 +130,36 @@ jobs:
                 `마지막 업데이트: ${formatElapsed(pr.updated_at)} 전`,
               ];
 
-              reminderEmbeds.push({
-                title: truncate(pr.title, 256),
-                url: pr.html_url,
-                description: descriptionLines.join('\n'),
-                color: 3447003,
-                footer: {
-                  text: `${context.repo.owner}/${context.repo.repo} • PR #${pr.number}`,
+              reminders.push({
+                embed: {
+                  title: truncate(pr.title, 256),
+                  url: pr.html_url,
+                  description: descriptionLines.join('\n'),
+                  color: 3447003,
+                  footer: {
+                    text: `${context.repo.owner}/${context.repo.repo} • PR #${pr.number}`,
+                  },
+                  timestamp: new Date().toISOString(),
                 },
-                timestamp: new Date().toISOString(),
+                mappedUserIds,
               });
               reminderCount += 1;
             }
 
-            for (let i = 0; i < reminderEmbeds.length; i += 10) {
-              const embedChunk = reminderEmbeds.slice(i, i + 10);
+            for (let i = 0; i < reminders.length; i += 10) {
+              const reminderChunk = reminders.slice(i, i + 10);
+              const chunkUserIds = Array.from(new Set(
+                reminderChunk.flatMap((reminder) => reminder.mappedUserIds)
+              ));
+              const mentionLine = chunkUserIds.map((id) => `<@${id}>`).join(' ');
               const payload = {
-                content: 'PR Review Reminder',
+                content: mentionLine ? `PR Review Reminder\n${mentionLine}` : 'PR Review Reminder',
                 allowed_mentions: {
                   parse: [],
-                  users: Array.from(allowedUserIds),
+                  users: chunkUserIds,
                   roles: [],
                 },
-                embeds: embedChunk,
+                embeds: reminderChunk.map((reminder) => reminder.embed),
               };
 
               const response = await fetch(`${webhookUrl}?wait=true`, {


### PR DESCRIPTION
## 작업 내용
- Discord PR 리뷰 리마인더 GitHub Actions 워크플로우 추가
- 매일 오전 10시(KST) 실행되도록 스케줄 설정
- draft PR은 제외하고, 개인 requested reviewer만 대상으로 Discord 멘션 전송
- PR 제목이 Discord embed에서 클릭 가능한 링크로 보이도록 구성
- GitHub 로그인과 Discord 사용자 ID 매핑은 repository variable JSON으로 읽도록 구성

## 설정 방법
- GitHub Secret: DISCORD_WEBHOOK_URL
- GitHub Variable: DISCORD_USER_MAP_JSON

## 테스트
- YAML 문법 검증
- workflow_dispatch로 수동 실행 가능

Closes #11