### PR TITLE
Feat : 매칭 요청/취소 및 상태 조회 API

### DIFF
--- a/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
+++ b/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
@@ -1,0 +1,17 @@
+package team.po.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.po.feature.match.exception.ProjectRequestNotFoundException;
+
+import java.util.Optional;
+
+@RestControllerAdvice
+public class CustomProjectRequestExceptionHandler {
+    @ExceptionHandler(ProjectRequestNotFoundException.class)
+    protected ResponseEntity<ExceptionResponse> projectRequestNotFoundException(ProjectRequestNotFoundException e) {
+        return ResponseEntity.status(e.getCode())
+                .body(new ExceptionResponse(e.getError(), e.getMessage(), Optional.empty()));
+    }
+}

--- a/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
+++ b/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
+import team.po.feature.match.exception.ProjectRequestCancelNotAllowedException;
 import team.po.feature.match.exception.ProjectRequestNotFoundException;
 
 import java.util.Optional;
@@ -18,6 +19,12 @@ public class CustomProjectRequestExceptionHandler {
 
     @ExceptionHandler(ProjectRequestAlreadyExistsException.class)
     protected ResponseEntity<ExceptionResponse> projectRequestAlreadyExistsException(ProjectRequestAlreadyExistsException e) {
+        return ResponseEntity.status(e.getCode())
+                .body(new ExceptionResponse(e.getError(), e.getMessage(), Optional.empty()));
+    }
+
+    @ExceptionHandler(ProjectRequestCancelNotAllowedException.class)
+    protected ResponseEntity<ExceptionResponse> projectRequestCancelNotAllowedException(ProjectRequestCancelNotAllowedException e) {
         return ResponseEntity.status(e.getCode())
                 .body(new ExceptionResponse(e.getError(), e.getMessage(), Optional.empty()));
     }

--- a/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
+++ b/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
@@ -3,6 +3,7 @@ package team.po.exception;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
 import team.po.feature.match.exception.ProjectRequestNotFoundException;
 
 import java.util.Optional;
@@ -11,6 +12,12 @@ import java.util.Optional;
 public class CustomProjectRequestExceptionHandler {
     @ExceptionHandler(ProjectRequestNotFoundException.class)
     protected ResponseEntity<ExceptionResponse> projectRequestNotFoundException(ProjectRequestNotFoundException e) {
+        return ResponseEntity.status(e.getCode())
+                .body(new ExceptionResponse(e.getError(), e.getMessage(), Optional.empty()));
+    }
+
+    @ExceptionHandler(ProjectRequestAlreadyExistsException.class)
+    protected ResponseEntity<ExceptionResponse> projectRequestAlreadyExistsException(ProjectRequestAlreadyExistsException e) {
         return ResponseEntity.status(e.getCode())
                 .body(new ExceptionResponse(e.getError(), e.getMessage(), Optional.empty()));
     }

--- a/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
+++ b/src/main/java/team/po/exception/CustomProjectRequestExceptionHandler.java
@@ -1,5 +1,7 @@
 package team.po.exception;
 
+import org.flywaydb.core.api.callback.Error;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -25,7 +27,8 @@ public class CustomProjectRequestExceptionHandler {
 
     @ExceptionHandler(ProjectRequestCancelNotAllowedException.class)
     protected ResponseEntity<ExceptionResponse> projectRequestCancelNotAllowedException(ProjectRequestCancelNotAllowedException e) {
-        return ResponseEntity.status(e.getCode())
-                .body(new ExceptionResponse(e.getError(), e.getMessage(), Optional.empty()));
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ExceptionResponse(ErrorCodeConstants.PROJECT_REQUEST_CANCEL_NOT_ALLOWED, "취소할 수 없는 상태입니다.", Optional.empty()));
     }
 }

--- a/src/main/java/team/po/exception/ErrorCodeConstants.java
+++ b/src/main/java/team/po/exception/ErrorCodeConstants.java
@@ -14,4 +14,5 @@ public final class ErrorCodeConstants extends RuntimeException {
 
 	// ProjectRequest
 	public static final String PROJECT_REQUEST_NOT_FOUND = "PROJECT_REQUEST_NOT_FOUND";
+	public static final String PROJECT_REQUEST_ALREADY_EXISTS = "PROJECT_REQUEST_ALREADY_EXISTS";
 }

--- a/src/main/java/team/po/exception/ErrorCodeConstants.java
+++ b/src/main/java/team/po/exception/ErrorCodeConstants.java
@@ -11,4 +11,7 @@ public final class ErrorCodeConstants extends RuntimeException {
 	public static final String NO_AUTHENTICATED_USER = "NO_AUTHENTICATED_USER";
 	public static final String INVALID_SECURITY_CONTEXT = "INVALID_SECURITY_CONTEXT";
 	public static final String UNMATCHED_PASSWORD = "UNMATCHED_PASSWORD";
+
+	// ProjectRequest
+	public static final String PROJECT_REQUEST_NOT_FOUND = "PROJECT_REQUEST_NOT_FOUND";
 }

--- a/src/main/java/team/po/exception/ErrorCodeConstants.java
+++ b/src/main/java/team/po/exception/ErrorCodeConstants.java
@@ -15,4 +15,5 @@ public final class ErrorCodeConstants extends RuntimeException {
 	// ProjectRequest
 	public static final String PROJECT_REQUEST_NOT_FOUND = "PROJECT_REQUEST_NOT_FOUND";
 	public static final String PROJECT_REQUEST_ALREADY_EXISTS = "PROJECT_REQUEST_ALREADY_EXISTS";
+	public static final String PROJECT_REQUEST_CANCEL_NOT_ALLOWED = "PROJECT_REQUEST_CANCEL_NOT_ALLOWED";
 }

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -5,6 +5,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.po.common.auth.LoginUser;
+import team.po.common.auth.LoginUserInfo;
 import team.po.feature.match.dto.ProjectRequestDto;
 import team.po.feature.match.service.ProjectRequestService;
 
@@ -19,6 +21,13 @@ public class ProjectRequestController {
     public ResponseEntity<Void> createProjectRequest(@Valid @RequestBody ProjectRequestDto dto){ // @Valid: 두 번째 파라미터 에러 받아서 처리
 
         projectRequestService.createProjectRequest(dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "매칭 취소 API")
+    @PatchMapping(value = "/cancel")
+    public ResponseEntity<Void> cancelProjectRequest(@LoginUser LoginUserInfo loginUser){
+        projectRequestService.cancelProjectRequest(loginUser);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -3,10 +3,14 @@ package team.po.feature.match.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 import team.po.common.auth.LoginUser;
 import team.po.common.auth.LoginUserInfo;
+import team.po.exception.ErrorCodeConstants;
+import team.po.exception.InvalidFieldException;
 import team.po.feature.match.dto.ProjectRequestDto;
 import team.po.feature.match.service.ProjectRequestService;
 
@@ -18,9 +22,16 @@ public class ProjectRequestController {
 
     @Operation(summary = "매칭 요청 API")
     @PostMapping(value = "/request")
-    public ResponseEntity<Void> createProjectRequest(@Valid @RequestBody ProjectRequestDto dto){ // @Valid: 두 번째 파라미터 에러 받아서 처리
-
-        projectRequestService.createProjectRequest(dto);
+    public ResponseEntity<Void> createProjectRequest(@LoginUser LoginUserInfo loginUser, @Valid @RequestBody ProjectRequestDto dto, Errors errors){ // @Valid: 두 번째 파라미터 에러 받아서 처리
+        if (errors.hasErrors()) {
+            throw new InvalidFieldException(
+                    HttpStatus.BAD_REQUEST,
+                    ErrorCodeConstants.INVALID_INPUT_FIELD,
+                    "입력값이 올바르지 않습니다.",
+                    errors
+            );
+        }
+        projectRequestService.createProjectRequest(loginUser, dto);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -8,12 +8,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 import team.po.common.auth.LoginUser;
-import team.po.common.auth.LoginUserInfo;
 import team.po.exception.ErrorCodeConstants;
 import team.po.exception.InvalidFieldException;
 import team.po.feature.match.dto.ProjectRequestDto;
 import team.po.feature.match.dto.ProjectRequestStatusResponse;
 import team.po.feature.match.service.ProjectRequestService;
+import team.po.feature.user.domain.Users;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class ProjectRequestController {
 
     @Operation(summary = "매칭 요청 API")
     @PostMapping(value = "/request")
-    public ResponseEntity<Void> createProjectRequest(@LoginUser LoginUserInfo loginUser, @Valid @RequestBody ProjectRequestDto request, Errors errors){ // @Valid: 두 번째 파라미터 에러 받아서 처리
+    public ResponseEntity<Void> createProjectRequest(@LoginUser Users user, @Valid @RequestBody ProjectRequestDto request, Errors errors){
         if (errors.hasErrors()) {
             throw new InvalidFieldException(
                     HttpStatus.BAD_REQUEST,
@@ -32,21 +32,21 @@ public class ProjectRequestController {
                     errors
             );
         }
-        projectRequestService.createProjectRequest(loginUser, request);
+        projectRequestService.createProjectRequest(user, request);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "매칭 취소 API")
     @PatchMapping(value = "/cancel")
-    public ResponseEntity<Void> cancelProjectRequest(@LoginUser LoginUserInfo loginUser){
-        projectRequestService.cancelProjectRequest(loginUser);
+    public ResponseEntity<Void> cancelProjectRequest(@LoginUser Users user){
+        projectRequestService.cancelProjectRequest(user);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "매칭 상태 조회 API")
     @GetMapping(value = "/status")
-    public ResponseEntity<ProjectRequestStatusResponse> getProjectRequestStatus(@LoginUser LoginUserInfo loginUser) {
-        ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(loginUser);
+    public ResponseEntity<ProjectRequestStatusResponse> getProjectRequestStatus(@LoginUser Users user) {
+        ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(user);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -1,0 +1,24 @@
+package team.po.feature.match.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.po.feature.match.dto.ProjectRequestDto;
+import team.po.feature.match.service.ProjectRequestService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/match")
+public class ProjectRequestController {
+    private final ProjectRequestService projectRequestService;
+
+    @Operation(summary = "매칭 요청 API")
+    @PostMapping(value = "/request")
+    public ResponseEntity<Void> createProjectRequest(@Valid @RequestBody ProjectRequestDto dto){ // @Valid: 두 번째 파라미터 에러 받아서 처리
+
+        projectRequestService.createProjectRequest(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -12,6 +12,7 @@ import team.po.common.auth.LoginUserInfo;
 import team.po.exception.ErrorCodeConstants;
 import team.po.exception.InvalidFieldException;
 import team.po.feature.match.dto.ProjectRequestDto;
+import team.po.feature.match.dto.ProjectRequestStatusResponse;
 import team.po.feature.match.service.ProjectRequestService;
 
 @RestController
@@ -40,5 +41,12 @@ public class ProjectRequestController {
     public ResponseEntity<Void> cancelProjectRequest(@LoginUser LoginUserInfo loginUser){
         projectRequestService.cancelProjectRequest(loginUser);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "매칭 상태 조회 API")
+    @GetMapping(value = "/status")
+    public ResponseEntity<ProjectRequestStatusResponse> getProjectRequestStatus(@LoginUser LoginUserInfo loginUser) {
+        ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(loginUser);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -23,7 +23,7 @@ public class ProjectRequestController {
 
     @Operation(summary = "매칭 요청 API")
     @PostMapping(value = "/request")
-    public ResponseEntity<Void> createProjectRequest(@LoginUser LoginUserInfo loginUser, @Valid @RequestBody ProjectRequestDto dto, Errors errors){ // @Valid: 두 번째 파라미터 에러 받아서 처리
+    public ResponseEntity<Void> createProjectRequest(@LoginUser LoginUserInfo loginUser, @Valid @RequestBody ProjectRequestDto request, Errors errors){ // @Valid: 두 번째 파라미터 에러 받아서 처리
         if (errors.hasErrors()) {
             throw new InvalidFieldException(
                     HttpStatus.BAD_REQUEST,
@@ -32,7 +32,7 @@ public class ProjectRequestController {
                     errors
             );
         }
-        projectRequestService.createProjectRequest(loginUser, dto);
+        projectRequestService.createProjectRequest(loginUser, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/team/po/feature/match/domain/ProjectRequest.java
+++ b/src/main/java/team/po/feature/match/domain/ProjectRequest.java
@@ -43,7 +43,7 @@ public class ProjectRequest {
     private Status status;
 
     @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
-    private Instant createAt;
+    private Instant createdAt;
 
     @Column(name = "canceled_at")
     private Instant canceledAt;

--- a/src/main/java/team/po/feature/match/domain/ProjectRequest.java
+++ b/src/main/java/team/po/feature/match/domain/ProjectRequest.java
@@ -1,0 +1,56 @@
+package team.po.feature.match.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.po.feature.user.domain.Users;
+
+@Entity
+@Table(name = "project_request")
+@NoArgsConstructor
+@Getter
+public class ProjectRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(name = "project_title")
+    private String projectTitle;
+
+    @Column(name = "project_description", columnDefinition = "TEXT")
+    private String projectDescription;
+
+    @Column(name = "project_mvp", columnDefinition = "TEXT")
+    private String projectMvp;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Builder
+    public ProjectRequest(Users user, Role role, String projectTitle,
+                          String projectDescription, String projectMvp) {
+        this.user = user;
+        this.role = role;
+        this.projectTitle = projectTitle;
+        this.projectDescription = projectDescription;
+        this.projectMvp = projectMvp;
+        this.status = Status.WAITING; // default
+    }
+
+    public enum Role {
+        DESIGN, BE, FE
+    }
+
+    public enum Status {
+        WAITING, MATCHING, MATCHED
+    }
+}

--- a/src/main/java/team/po/feature/match/domain/ProjectRequest.java
+++ b/src/main/java/team/po/feature/match/domain/ProjectRequest.java
@@ -61,11 +61,7 @@ public class ProjectRequest {
 
     public void cancel() {
         if (this.status != Status.WAITING && this.status != Status.MATCHING) {
-            throw new ProjectRequestCancelNotAllowedException(
-                    HttpStatus.BAD_REQUEST,
-                    ErrorCodeConstants.PROJECT_REQUEST_CANCEL_NOT_ALLOWED,
-                    "취소할 수 없는 상태입니다."
-            );
+            throw new ProjectRequestCancelNotAllowedException();
         }
         this.status = Status.CANCELED;
         this.canceledAt = Instant.now();

--- a/src/main/java/team/po/feature/match/domain/ProjectRequest.java
+++ b/src/main/java/team/po/feature/match/domain/ProjectRequest.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.po.feature.match.enums.Role;
+import team.po.feature.match.enums.Status;
 import team.po.feature.user.domain.Users;
 
 @Entity
@@ -44,13 +46,5 @@ public class ProjectRequest {
         this.projectDescription = projectDescription;
         this.projectMvp = projectMvp;
         this.status = Status.WAITING; // default
-    }
-
-    public enum Role {
-        DESIGN, BE, FE
-    }
-
-    public enum Status {
-        WAITING, MATCHING, MATCHED
     }
 }

--- a/src/main/java/team/po/feature/match/domain/ProjectRequest.java
+++ b/src/main/java/team/po/feature/match/domain/ProjectRequest.java
@@ -4,8 +4,11 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import team.po.exception.ErrorCodeConstants;
 import team.po.feature.match.enums.Role;
 import team.po.feature.match.enums.Status;
+import team.po.feature.match.exception.ProjectRequestCancelNotAllowedException;
 import team.po.feature.user.domain.Users;
 
 import java.time.Instant;
@@ -57,6 +60,13 @@ public class ProjectRequest {
     }
 
     public void cancel() {
+        if (this.status != Status.WAITING && this.status != Status.MATCHING) {
+            throw new ProjectRequestCancelNotAllowedException(
+                    HttpStatus.BAD_REQUEST,
+                    ErrorCodeConstants.PROJECT_REQUEST_CANCEL_NOT_ALLOWED,
+                    "취소할 수 없는 상태입니다."
+            );
+        }
         this.status = Status.CANCELED;
         this.canceledAt = Instant.now();
     }

--- a/src/main/java/team/po/feature/match/domain/ProjectRequest.java
+++ b/src/main/java/team/po/feature/match/domain/ProjectRequest.java
@@ -8,6 +8,8 @@ import team.po.feature.match.enums.Role;
 import team.po.feature.match.enums.Status;
 import team.po.feature.user.domain.Users;
 
+import java.time.Instant;
+
 @Entity
 @Table(name = "project_request")
 @NoArgsConstructor
@@ -37,6 +39,12 @@ public class ProjectRequest {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private Instant createAt;
+
+    @Column(name = "canceled_at")
+    private Instant canceledAt;
+
     @Builder
     public ProjectRequest(Users user, Role role, String projectTitle,
                           String projectDescription, String projectMvp) {
@@ -46,5 +54,10 @@ public class ProjectRequest {
         this.projectDescription = projectDescription;
         this.projectMvp = projectMvp;
         this.status = Status.WAITING; // default
+    }
+
+    public void cancel() {
+        this.status = Status.CANCELED;
+        this.canceledAt = Instant.now();
     }
 }

--- a/src/main/java/team/po/feature/match/dto/ProjectRequestDto.java
+++ b/src/main/java/team/po/feature/match/dto/ProjectRequestDto.java
@@ -2,11 +2,11 @@ package team.po.feature.match.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import team.po.feature.match.domain.ProjectRequest;
+import team.po.feature.match.enums.Role;
 
 public record ProjectRequestDto(
         @NotNull(message = "역할 선택은 필수입니다.")
-        ProjectRequest.Role role,
+        Role role,
         @NotBlank(message = "프로젝트 제목 입력은 필수입니다.")
         String projectTitle,
         String projectDescription,

--- a/src/main/java/team/po/feature/match/dto/ProjectRequestDto.java
+++ b/src/main/java/team/po/feature/match/dto/ProjectRequestDto.java
@@ -7,7 +7,6 @@ import team.po.feature.match.enums.Role;
 public record ProjectRequestDto(
         @NotNull(message = "역할 선택은 필수입니다.")
         Role role,
-        @NotBlank(message = "프로젝트 제목 입력은 필수입니다.")
         String projectTitle,
         String projectDescription,
         String projectMvp

--- a/src/main/java/team/po/feature/match/dto/ProjectRequestDto.java
+++ b/src/main/java/team/po/feature/match/dto/ProjectRequestDto.java
@@ -1,0 +1,15 @@
+package team.po.feature.match.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import team.po.feature.match.domain.ProjectRequest;
+
+public record ProjectRequestDto(
+        @NotNull(message = "역할 선택은 필수입니다.")
+        ProjectRequest.Role role,
+        @NotBlank(message = "프로젝트 제목 입력은 필수입니다.")
+        String projectTitle,
+        String projectDescription,
+        String projectMvp
+) {
+}

--- a/src/main/java/team/po/feature/match/dto/ProjectRequestStatusResponse.java
+++ b/src/main/java/team/po/feature/match/dto/ProjectRequestStatusResponse.java
@@ -1,4 +1,8 @@
 package team.po.feature.match.dto;
 
-public record ProjectRequestStatusResponse() {
+import team.po.feature.match.enums.Status;
+
+public record ProjectRequestStatusResponse(
+        Status status
+) {
 }

--- a/src/main/java/team/po/feature/match/dto/ProjectRequestStatusResponse.java
+++ b/src/main/java/team/po/feature/match/dto/ProjectRequestStatusResponse.java
@@ -1,0 +1,4 @@
+package team.po.feature.match.dto;
+
+public record ProjectRequestStatusResponse() {
+}

--- a/src/main/java/team/po/feature/match/enums/Role.java
+++ b/src/main/java/team/po/feature/match/enums/Role.java
@@ -1,0 +1,5 @@
+package team.po.feature.match.enums;
+
+public enum Role {
+    DESIGN, BE, FE
+}

--- a/src/main/java/team/po/feature/match/enums/Status.java
+++ b/src/main/java/team/po/feature/match/enums/Status.java
@@ -1,0 +1,5 @@
+package team.po.feature.match.enums;
+
+public enum Status {
+    WAITING, MATCHING, MATCHED
+}

--- a/src/main/java/team/po/feature/match/enums/Status.java
+++ b/src/main/java/team/po/feature/match/enums/Status.java
@@ -1,5 +1,5 @@
 package team.po.feature.match.enums;
 
 public enum Status {
-    WAITING, MATCHING, MATCHED
+    WAITING, MATCHING, MATCHED, CANCELED
 }

--- a/src/main/java/team/po/feature/match/exception/ProjectRequestAlreadyExistsException.java
+++ b/src/main/java/team/po/feature/match/exception/ProjectRequestAlreadyExistsException.java
@@ -1,0 +1,17 @@
+package team.po.feature.match.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ProjectRequestAlreadyExistsException extends RuntimeException {
+    private final HttpStatus code;
+    private final String error;
+    private final String message;
+
+    public ProjectRequestAlreadyExistsException(HttpStatus code, String error, String message) {
+        this.code = code;
+        this.error = error;
+        this.message = message;
+    }
+}

--- a/src/main/java/team/po/feature/match/exception/ProjectRequestAlreadyExistsException.java
+++ b/src/main/java/team/po/feature/match/exception/ProjectRequestAlreadyExistsException.java
@@ -1,17 +1,13 @@
 package team.po.feature.match.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@RequiredArgsConstructor
 public class ProjectRequestAlreadyExistsException extends RuntimeException {
     private final HttpStatus code;
     private final String error;
     private final String message;
-
-    public ProjectRequestAlreadyExistsException(HttpStatus code, String error, String message) {
-        this.code = code;
-        this.error = error;
-        this.message = message;
-    }
 }

--- a/src/main/java/team/po/feature/match/exception/ProjectRequestCancelNotAllowedException.java
+++ b/src/main/java/team/po/feature/match/exception/ProjectRequestCancelNotAllowedException.java
@@ -4,14 +4,4 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class ProjectRequestCancelNotAllowedException extends RuntimeException {
-    private final HttpStatus code;
-    private final String error;
-    private final String message;
-
-    public ProjectRequestCancelNotAllowedException(HttpStatus code, String error, String message) {
-      this.code = code;
-      this.error = error;
-      this.message = message;
-    }
-}
+public class ProjectRequestCancelNotAllowedException extends RuntimeException { }

--- a/src/main/java/team/po/feature/match/exception/ProjectRequestCancelNotAllowedException.java
+++ b/src/main/java/team/po/feature/match/exception/ProjectRequestCancelNotAllowedException.java
@@ -1,0 +1,17 @@
+package team.po.feature.match.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ProjectRequestCancelNotAllowedException extends RuntimeException {
+    private final HttpStatus code;
+    private final String error;
+    private final String message;
+
+    public ProjectRequestCancelNotAllowedException(HttpStatus code, String error, String message) {
+      this.code = code;
+      this.error = error;
+      this.message = message;
+    }
+}

--- a/src/main/java/team/po/feature/match/exception/ProjectRequestNotFoundException.java
+++ b/src/main/java/team/po/feature/match/exception/ProjectRequestNotFoundException.java
@@ -1,17 +1,13 @@
 package team.po.feature.match.exception;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
+@RequiredArgsConstructor
 public class ProjectRequestNotFoundException extends RuntimeException {
     private final HttpStatus code;
     private final String error;
     private final String message;
-
-    public ProjectRequestNotFoundException(HttpStatus code, String error, String message) {
-        this.code = code;
-        this.error = error;
-        this.message = message;
-    }
 }

--- a/src/main/java/team/po/feature/match/exception/ProjectRequestNotFoundException.java
+++ b/src/main/java/team/po/feature/match/exception/ProjectRequestNotFoundException.java
@@ -1,0 +1,17 @@
+package team.po.feature.match.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ProjectRequestNotFoundException extends RuntimeException {
+    private final HttpStatus code;
+    private final String error;
+    private final String message;
+
+    public ProjectRequestNotFoundException(HttpStatus code, String error, String message) {
+        this.code = code;
+        this.error = error;
+        this.message = message;
+    }
+}

--- a/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
+++ b/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ProjectRequestRepository extends JpaRepository<ProjectRequest, Long> {
+    public boolean existsByUserIdAndStatusIn(Long userId, List<Status> statuses);
+
     public Optional<ProjectRequest> findByUserIdAndStatusIn(Long userId, List<Status> statuses);
 }

--- a/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
+++ b/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
@@ -1,0 +1,7 @@
+package team.po.feature.match.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.po.feature.match.domain.ProjectRequest;
+
+public interface ProjectRequestRepository extends JpaRepository<ProjectRequest, Long> {
+}

--- a/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
+++ b/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
@@ -2,6 +2,11 @@ package team.po.feature.match.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.po.feature.match.domain.ProjectRequest;
+import team.po.feature.match.enums.Status;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ProjectRequestRepository extends JpaRepository<ProjectRequest, Long> {
+    public Optional<ProjectRequest> findByUserIdAndStatusIn(Long userId, List<Status> statuses);
 }

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -6,7 +6,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.po.common.auth.LoginUserInfo;
 import team.po.exception.ErrorCodeConstants;
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestDto;
@@ -30,10 +29,13 @@ public class ProjectRequestService {
 
 
     @Transactional
-    public void createProjectRequest(LoginUserInfo loginUser, ProjectRequestDto request) {
-        // @LoginUser 수정 후 삭제
-        Users user = this.getActiveUser(loginUser.id());
-
+    public void createProjectRequest(Users loginUser, ProjectRequestDto request) {
+        Users user = userRepository.findByIdAndDeletedAtIsNull(loginUser.getId())
+                .orElseThrow(() -> new UserNotFoundException(
+                        HttpStatus.UNAUTHORIZED,
+                        ErrorCodeConstants.UNEXISTED_USER,
+                        "존재하지 않는 유저입니다."
+                ));
         boolean matchingExists = projectRequestRepository.existsByUserIdAndStatusIn(
                 user.getId(),
                 List.of(Status.WAITING, Status.MATCHING)
@@ -78,10 +80,7 @@ public class ProjectRequestService {
     }
 
     @Transactional
-    public void cancelProjectRequest(LoginUserInfo loginUser){
-        // @LoginUser 수정 후 삭제
-        Users user = this.getActiveUser(loginUser.id());
-
+    public void cancelProjectRequest(Users user){
         ProjectRequest projectRequest = projectRequestRepository.findByUserIdAndStatusIn(
                 user.getId(),
                 List.of(Status.WAITING, Status.MATCHING)
@@ -94,10 +93,7 @@ public class ProjectRequestService {
     }
 
     @Transactional(readOnly = true)
-    public ProjectRequestStatusResponse getProjectRequestStatus(LoginUserInfo loginUser) {
-        // @LoginUser 수정 후 삭제
-        Users user = this.getActiveUser(loginUser.id());
-
+    public ProjectRequestStatusResponse getProjectRequestStatus(Users user) {
         ProjectRequest projectRequest = projectRequestRepository.findByUserIdAndStatusIn(
                 user.getId(),
                 List.of(Status.WAITING, Status.MATCHING)
@@ -108,15 +104,5 @@ public class ProjectRequestService {
         ));
 
         return new ProjectRequestStatusResponse(projectRequest.getStatus());
-    }
-
-    // @LoginUser 수정하면 삭제 예정
-    private Users getActiveUser(Long userId) {
-        return userRepository.findByIdAndDeletedAtIsNull(userId)
-                .orElseThrow(() -> new UserNotFoundException(
-                        HttpStatus.UNAUTHORIZED,
-                        ErrorCodeConstants.UNEXISTED_USER,
-                        "존재하지 않는 유저입니다."
-                ));
     }
 }

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -4,10 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import team.po.common.auth.LoginUser;
 import team.po.common.auth.LoginUserInfo;
 import team.po.exception.ErrorCodeConstants;
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestDto;
+import team.po.feature.match.dto.ProjectRequestStatusResponse;
 import team.po.feature.match.enums.Status;
 import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
 import team.po.feature.match.exception.ProjectRequestNotFoundException;
@@ -67,12 +69,27 @@ public class ProjectRequestService {
         request.cancel();
     }
 
+    public ProjectRequestStatusResponse getProjectRequestStatus(LoginUserInfo loginUser) {
+        getActiveUser(loginUser.id());
+
+        ProjectRequest request = projectRequestRepository.findByUserIdAndStatusIn(
+                loginUser.id(),
+                List.of(Status.WAITING, Status.MATCHING)
+        ).orElseThrow(() -> new ProjectRequestNotFoundException(
+                HttpStatus.NOT_FOUND,
+                ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
+                "진행 중인 매칭 요청이 없습니다."
+        ));
+
+        return new ProjectRequestStatusResponse(request.getStatus());
+    }
+
     private Users getActiveUser(Long userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new UserNotFoundException(
                         HttpStatus.UNAUTHORIZED,
                         ErrorCodeConstants.UNEXISTED_USER,
-                        "존재하지 않은 유저입니다."
+                        "존재하지 않는 유저입니다."
                 ));
     }
 }

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -13,6 +13,7 @@ import team.po.feature.match.enums.Status;
 import team.po.feature.match.exception.ProjectRequestNotFoundException;
 import team.po.feature.match.repository.ProjectRequestRepository;
 import team.po.feature.user.domain.Users;
+import team.po.feature.user.exception.UserNotFoundException;
 import team.po.feature.user.repository.UserRepository;
 
 import java.util.List;
@@ -28,7 +29,6 @@ public class ProjectRequestService {
     public void createProjectRequest(ProjectRequestDto dto) {
         // Controller에서 User 직접 주입
         // 이메일 전달 X 토큰으로 처리
-
         Users user;
 
         ProjectRequest request = ProjectRequest.builder()
@@ -47,16 +47,26 @@ public class ProjectRequestService {
     }
 
     public void cancelProjectRequest(LoginUserInfo loginUser){
-        // UserId + (Status == WAITING || Status == MATCHING)인 요청 찾기
+        // validate active user
+        this.getActiveUser(loginUser.id());
+
         ProjectRequest request = projectRequestRepository.findByUserIdAndStatusIn(
-                loginUser.id(), // login user 정보는 controller에서 주입
+                loginUser.id(), // Controller
                 List.of(Status.WAITING, Status.MATCHING)
         ).orElseThrow(() -> new ProjectRequestNotFoundException(
                 HttpStatus.NOT_FOUND,
                 ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
                 "취소할 수 있는 매칭 요청이 없습니다."
         ));
-        // 그 요청.cancel
         request.cancel();
+    }
+
+    private Users getActiveUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new UserNotFoundException(
+                        HttpStatus.UNAUTHORIZED,
+                        ErrorCodeConstants.UNEXISTED_USER,
+                        "존재하지 않은 유저입니다."
+                ));
     }
 }

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -31,13 +31,12 @@ public class ProjectRequestService {
 
     @Transactional
     public void createProjectRequest(LoginUserInfo loginUser, ProjectRequestDto request) {
+        // @LoginUser 수정 후 삭제
         Users user = this.getActiveUser(loginUser.id());
 
         boolean matchingExists = projectRequestRepository.existsByUserIdAndStatusIn(
                 user.getId(),
-                List.of(Status.WAITING, Status.MATCHING, Status.MATCHED)
-                // TODO: MATCHED인 경우 ProjectGroup.status 확인 필요
-                // 프로젝트가 종료된 경우에만 새 매칭 요청 가능
+                List.of(Status.WAITING, Status.MATCHING)
         );
         if (matchingExists) {
             throw new ProjectRequestAlreadyExistsException(
@@ -46,6 +45,19 @@ public class ProjectRequestService {
                     "이미 진행 중인 매칭 요청이 있습니다."
             );
         }
+
+        // TODO: ProjectGroup 구현 후 추가
+        // ProjectGroup.status - 프로젝트 진행 중 -> X
+//        boolean projectInProgress = projectGroupRepository.existsByUserIdAndStatus(
+//                user.getId(),
+//                ProjectGroupStatus.IN_PROGRESS);
+//        if (projectInProgress) {
+//            throw new ProjectAlreadyInProgressException(
+//                    HttpStatus.CONFLICT,
+//                    ErrorCodeConstants.PROJECT_ALREADY_IN_PROGRESS,
+//                    "이미 진행 중인 프로젝트가 있습니다."
+//            )
+//        }
 
         try {
             ProjectRequest projectRequest = ProjectRequest.builder()
@@ -67,7 +79,7 @@ public class ProjectRequestService {
 
     @Transactional
     public void cancelProjectRequest(LoginUserInfo loginUser){
-        // validate active user
+        // @LoginUser 수정 후 삭제
         Users user = this.getActiveUser(loginUser.id());
 
         ProjectRequest projectRequest = projectRequestRepository.findByUserIdAndStatusIn(
@@ -83,6 +95,7 @@ public class ProjectRequestService {
 
     @Transactional(readOnly = true)
     public ProjectRequestStatusResponse getProjectRequestStatus(LoginUserInfo loginUser) {
+        // @LoginUser 수정 후 삭제
         Users user = this.getActiveUser(loginUser.id());
 
         ProjectRequest projectRequest = projectRequestRepository.findByUserIdAndStatusIn(

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -30,11 +30,11 @@ public class ProjectRequestService {
 
 
     @Transactional
-    public void createProjectRequest(LoginUserInfo loginUser, ProjectRequestDto dto) {
+    public void createProjectRequest(LoginUserInfo loginUser, ProjectRequestDto request) {
         Users user = this.getActiveUser(loginUser.id());
 
         boolean matchingExists = projectRequestRepository.existsByUserIdAndStatusIn(
-                loginUser.id(),
+                user.getId(),
                 List.of(Status.WAITING, Status.MATCHING, Status.MATCHED)
                 // TODO: MATCHED인 경우 ProjectGroup.status 확인 필요
                 // 프로젝트가 종료된 경우에만 새 매칭 요청 가능
@@ -48,14 +48,14 @@ public class ProjectRequestService {
         }
 
         try {
-            ProjectRequest request = ProjectRequest.builder()
+            ProjectRequest projectRequest = ProjectRequest.builder()
                     .user(user)
-                    .role(dto.role())
-                    .projectTitle(dto.projectTitle())
-                    .projectDescription(dto.projectDescription())
-                    .projectMvp(dto.projectMvp())
+                    .role(request.role())
+                    .projectTitle(request.projectTitle())
+                    .projectDescription(request.projectDescription())
+                    .projectMvp(request.projectMvp())
                     .build();
-            projectRequestRepository.save(request);
+            projectRequestRepository.save(projectRequest);
         } catch (DataIntegrityViolationException e) { // 동시 요청 Race Condition
             throw new ProjectRequestAlreadyExistsException(
                     HttpStatus.CONFLICT,
@@ -68,25 +68,25 @@ public class ProjectRequestService {
     @Transactional
     public void cancelProjectRequest(LoginUserInfo loginUser){
         // validate active user
-        this.getActiveUser(loginUser.id());
+        Users user = this.getActiveUser(loginUser.id());
 
-        ProjectRequest request = projectRequestRepository.findByUserIdAndStatusIn(
-                loginUser.id(), // Controller
+        ProjectRequest projectRequest = projectRequestRepository.findByUserIdAndStatusIn(
+                user.getId(),
                 List.of(Status.WAITING, Status.MATCHING)
         ).orElseThrow(() -> new ProjectRequestNotFoundException(
                 HttpStatus.NOT_FOUND,
                 ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
                 "취소할 수 있는 매칭 요청이 없습니다."
         ));
-        request.cancel();
+        projectRequest.cancel();
     }
 
     @Transactional(readOnly = true)
     public ProjectRequestStatusResponse getProjectRequestStatus(LoginUserInfo loginUser) {
-        this.getActiveUser(loginUser.id());
+        Users user = this.getActiveUser(loginUser.id());
 
-        ProjectRequest request = projectRequestRepository.findByUserIdAndStatusIn(
-                loginUser.id(),
+        ProjectRequest projectRequest = projectRequestRepository.findByUserIdAndStatusIn(
+                user.getId(),
                 List.of(Status.WAITING, Status.MATCHING)
         ).orElseThrow(() -> new ProjectRequestNotFoundException(
                 HttpStatus.NOT_FOUND,
@@ -94,9 +94,10 @@ public class ProjectRequestService {
                 "진행 중인 매칭 요청이 없습니다."
         ));
 
-        return new ProjectRequestStatusResponse(request.getStatus());
+        return new ProjectRequestStatusResponse(projectRequest.getStatus());
     }
 
+    // @LoginUser 수정하면 삭제 예정
     private Users getActiveUser(Long userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new UserNotFoundException(

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -33,7 +33,7 @@ public class ProjectRequestService {
 
         boolean matchingExists = projectRequestRepository.existsByUserIdAndStatusIn(
                 loginUser.id(),
-                List.of(Status.MATCHING, Status.WAITING)
+                List.of(Status.WAITING, Status.MATCHING)
         );
         if (matchingExists) {
             throw new ProjectRequestAlreadyExistsException(
@@ -70,7 +70,7 @@ public class ProjectRequestService {
     }
 
     public ProjectRequestStatusResponse getProjectRequestStatus(LoginUserInfo loginUser) {
-        getActiveUser(loginUser.id());
+        this.getActiveUser(loginUser.id());
 
         ProjectRequest request = projectRequestRepository.findByUserIdAndStatusIn(
                 loginUser.id(),

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -1,0 +1,41 @@
+package team.po.feature.match.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import team.po.common.util.SecurityUtil;
+import team.po.feature.match.domain.ProjectRequest;
+import team.po.feature.match.dto.ProjectRequestDto;
+import team.po.feature.match.repository.ProjectRequestRepository;
+import team.po.feature.user.domain.Users;
+import team.po.feature.user.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProjectRequestService {
+    private final ProjectRequestRepository projectRequestRepository;
+    private final UserRepository userRepository;
+
+
+    public void createProjectRequest(ProjectRequestDto dto) {
+        // Controller에서 User 직접 주입
+        // 이메일 전달 X 토큰으로 처리
+
+        Users user;
+
+        ProjectRequest request = ProjectRequest.builder()
+                .user(user)
+                .role(dto.role())
+                .projectTitle(dto.projectTitle())
+                .projectDescription(dto.projectDescription())
+                .projectMvp(dto.projectMvp())
+                .build();
+
+        projectRequestRepository.save(request);
+
+        // 저장하기 전에 따닥 중복 막아야 됨
+        // 중복 검사나 엣지케이스 처리
+        //
+    }
+}

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -5,11 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.po.common.auth.LoginUserInfo;
-import team.po.common.util.SecurityUtil;
 import team.po.exception.ErrorCodeConstants;
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestDto;
 import team.po.feature.match.enums.Status;
+import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
 import team.po.feature.match.exception.ProjectRequestNotFoundException;
 import team.po.feature.match.repository.ProjectRequestRepository;
 import team.po.feature.user.domain.Users;
@@ -26,10 +26,20 @@ public class ProjectRequestService {
     private final UserRepository userRepository;
 
 
-    public void createProjectRequest(ProjectRequestDto dto) {
-        // Controller에서 User 직접 주입
-        // 이메일 전달 X 토큰으로 처리
-        Users user;
+    public void createProjectRequest(LoginUserInfo loginUser, ProjectRequestDto dto) {
+        Users user = this.getActiveUser(loginUser.id());
+
+        boolean matchingExists = projectRequestRepository.existsByUserIdAndStatusIn(
+                loginUser.id(),
+                List.of(Status.MATCHING, Status.WAITING)
+        );
+        if (matchingExists) {
+            throw new ProjectRequestAlreadyExistsException(
+                    HttpStatus.CONFLICT,
+                    ErrorCodeConstants.PROJECT_REQUEST_ALREADY_EXISTS,
+                    "이미 진행 중인 매칭 요청이 있습니다."
+            );
+        }
 
         ProjectRequest request = ProjectRequest.builder()
                 .user(user)
@@ -40,10 +50,6 @@ public class ProjectRequestService {
                 .build();
 
         projectRequestRepository.save(request);
-
-        // 저장하기 전에 따닥 중복 막아야 됨
-        // 중복 검사나 엣지케이스 처리
-        //
     }
 
     public void cancelProjectRequest(LoginUserInfo loginUser){

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -2,13 +2,20 @@ package team.po.feature.match.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import team.po.common.auth.LoginUserInfo;
 import team.po.common.util.SecurityUtil;
+import team.po.exception.ErrorCodeConstants;
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestDto;
+import team.po.feature.match.enums.Status;
+import team.po.feature.match.exception.ProjectRequestNotFoundException;
 import team.po.feature.match.repository.ProjectRequestRepository;
 import team.po.feature.user.domain.Users;
 import team.po.feature.user.repository.UserRepository;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -37,5 +44,19 @@ public class ProjectRequestService {
         // 저장하기 전에 따닥 중복 막아야 됨
         // 중복 검사나 엣지케이스 처리
         //
+    }
+
+    public void cancelProjectRequest(LoginUserInfo loginUser){
+        // UserId + (Status == WAITING || Status == MATCHING)인 요청 찾기
+        ProjectRequest request = projectRequestRepository.findByUserIdAndStatusIn(
+                loginUser.id(), // login user 정보는 controller에서 주입
+                List.of(Status.WAITING, Status.MATCHING)
+        ).orElseThrow(() -> new ProjectRequestNotFoundException(
+                HttpStatus.NOT_FOUND,
+                ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
+                "취소할 수 있는 매칭 요청이 없습니다."
+        ));
+        // 그 요청.cancel
+        request.cancel();
     }
 }

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -2,9 +2,10 @@ package team.po.feature.match.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import team.po.common.auth.LoginUser;
+import org.springframework.transaction.annotation.Transactional;
 import team.po.common.auth.LoginUserInfo;
 import team.po.exception.ErrorCodeConstants;
 import team.po.feature.match.domain.ProjectRequest;
@@ -28,12 +29,15 @@ public class ProjectRequestService {
     private final UserRepository userRepository;
 
 
+    @Transactional
     public void createProjectRequest(LoginUserInfo loginUser, ProjectRequestDto dto) {
         Users user = this.getActiveUser(loginUser.id());
 
         boolean matchingExists = projectRequestRepository.existsByUserIdAndStatusIn(
                 loginUser.id(),
-                List.of(Status.WAITING, Status.MATCHING)
+                List.of(Status.WAITING, Status.MATCHING, Status.MATCHED)
+                // TODO: MATCHED인 경우 ProjectGroup.status 확인 필요
+                // 프로젝트가 종료된 경우에만 새 매칭 요청 가능
         );
         if (matchingExists) {
             throw new ProjectRequestAlreadyExistsException(
@@ -43,17 +47,25 @@ public class ProjectRequestService {
             );
         }
 
-        ProjectRequest request = ProjectRequest.builder()
-                .user(user)
-                .role(dto.role())
-                .projectTitle(dto.projectTitle())
-                .projectDescription(dto.projectDescription())
-                .projectMvp(dto.projectMvp())
-                .build();
-
-        projectRequestRepository.save(request);
+        try {
+            ProjectRequest request = ProjectRequest.builder()
+                    .user(user)
+                    .role(dto.role())
+                    .projectTitle(dto.projectTitle())
+                    .projectDescription(dto.projectDescription())
+                    .projectMvp(dto.projectMvp())
+                    .build();
+            projectRequestRepository.save(request);
+        } catch (DataIntegrityViolationException e) { // 동시 요청 Race Condition
+            throw new ProjectRequestAlreadyExistsException(
+                    HttpStatus.CONFLICT,
+                    ErrorCodeConstants.PROJECT_REQUEST_ALREADY_EXISTS,
+                    "이미 진행 중인 매칭 요청이 있습니다."
+            );
+        }
     }
 
+    @Transactional
     public void cancelProjectRequest(LoginUserInfo loginUser){
         // validate active user
         this.getActiveUser(loginUser.id());
@@ -69,6 +81,7 @@ public class ProjectRequestService {
         request.cancel();
     }
 
+    @Transactional(readOnly = true)
     public ProjectRequestStatusResponse getProjectRequestStatus(LoginUserInfo loginUser) {
         this.getActiveUser(loginUser.id());
 

--- a/src/main/resources/db/migration/V3__create_project_request_schema.sql
+++ b/src/main/resources/db/migration/V3__create_project_request_schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE project_request (
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id             BIGINT       NOT NULL,
+    role              VARCHAR(255) NOT NULL,
+    project_title       VARCHAR(255) NOT NULL,
+    project_description TEXT,
+    project_mvp         TEXT,
+    status VARCHAR(255) NOT NULL DEFAULT 'WAITING',
+    CONSTRAINT fk_project_request_user FOREIGN KEY (user_id) REFERENCES users(id)
+);

--- a/src/main/resources/db/migration/V4__create_project_request_schema.sql
+++ b/src/main/resources/db/migration/V4__create_project_request_schema.sql
@@ -6,5 +6,7 @@ CREATE TABLE project_request (
     project_description TEXT,
     project_mvp         TEXT,
     status VARCHAR(255) NOT NULL DEFAULT 'WAITING',
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    canceled_at DATETIME(6) NULL,
     CONSTRAINT fk_project_request_user FOREIGN KEY (user_id) REFERENCES users(id)
 );

--- a/src/main/resources/db/migration/V4__create_project_request_schema.sql
+++ b/src/main/resources/db/migration/V4__create_project_request_schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE project_request (
     id                  BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id             BIGINT       NOT NULL,
     role              VARCHAR(255) NOT NULL,
-    project_title       VARCHAR(255) NOT NULL,
+    project_title       VARCHAR(255),
     project_description TEXT,
     project_mvp         TEXT,
     status VARCHAR(255) NOT NULL DEFAULT 'WAITING',

--- a/src/main/resources/db/migration/V5__add_unique_index_active_project_request.sql
+++ b/src/main/resources/db/migration/V5__add_unique_index_active_project_request.sql
@@ -1,3 +1,5 @@
-CREATE UNIQUE INDEX uq_active_request_per_user
-ON project_request(user_id)
-WHERE status IN ('WAITING', 'MATCHING', 'MATCHED');
+ALTER TABLE project_request
+    ADD COLUMN active_user_id BIGINT AS (
+    CASE WHEN status IN ('WAITING', 'MATCHING', 'MATCHED') THEN user_id ELSE NULL END
+) VIRTUAL,
+ADD UNIQUE INDEX uq_active_request_per_user (active_user_id);

--- a/src/main/resources/db/migration/V5__add_unique_index_active_project_request.sql
+++ b/src/main/resources/db/migration/V5__add_unique_index_active_project_request.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX uq_active_request_per_user
+ON project_request(user_id)
+WHERE status IN ('WAITING', 'MATCHING', 'MATCHED');

--- a/src/test/java/team/po/feature/match/controller/ProjectRequestControllerTest.java
+++ b/src/test/java/team/po/feature/match/controller/ProjectRequestControllerTest.java
@@ -1,0 +1,155 @@
+package team.po.feature.match.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import team.po.common.jwt.UserPrincipal;
+import team.po.exception.CustomProjectRequestExceptionHandler;
+import team.po.exception.ErrorCodeConstants;
+import team.po.feature.match.domain.ProjectRequest;
+import team.po.feature.match.dto.ProjectRequestStatusResponse;
+import team.po.feature.match.enums.Status;
+import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
+import team.po.feature.match.exception.ProjectRequestNotFoundException;
+import team.po.feature.match.service.ProjectRequestService;
+
+import java.util.List;
+
+@WebMvcTest(ProjectRequestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(CustomProjectRequestExceptionHandler.class)
+class ProjectRequestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProjectRequestService projectRequestService;
+
+    @BeforeEach
+    void setUp() {
+        UserPrincipal principal = new UserPrincipal(1L, "test@email.com");
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principal, null, List.of()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    // ===== createProjectRequest =====
+
+    @Test
+    void createProjectRequest_returnsOk_whenRequestIsValid() throws Exception {
+        mockMvc.perform(post("/api/match/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {"role": "BE", "projectTitle": null, "projectDescription": "desc", "projectMvp": "mvp"}
+                    """))
+                .andExpect(status().isOk());
+
+        verify(projectRequestService).createProjectRequest(any(), any());
+    }
+
+    @Test
+    void createProjectRequest_returnsBadRequest_whenRoleIsNull() throws Exception {
+        mockMvc.perform(post("/api/match/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {"role": null, "projectTitle": null, "projectDescription": "desc", "projectMvp": "mvp"}
+                    """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCodeConstants.INVALID_INPUT_FIELD));
+    }
+
+    @Test
+    void createProjectRequest_returnsConflict_whenDuplicateRequest() throws Exception {
+        doThrow(new ProjectRequestAlreadyExistsException(
+                HttpStatus.CONFLICT,
+                ErrorCodeConstants.PROJECT_REQUEST_ALREADY_EXISTS,
+                "이미 진행 중인 매칭 요청이 있습니다."
+        )).when(projectRequestService).createProjectRequest(any(), any());
+
+        mockMvc.perform(post("/api/match/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                    {"role": "BE", "projectTitle": null, "projectDescription": "desc", "projectMvp": "mvp"}
+                    """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(ErrorCodeConstants.PROJECT_REQUEST_ALREADY_EXISTS))
+                .andExpect(jsonPath("$.message").value("이미 진행 중인 매칭 요청이 있습니다."));
+    }
+
+    // ===== cancelProjectRequest =====
+
+    @Test
+    void cancelProjectRequest_returnsOk() throws Exception {
+        mockMvc.perform(patch("/api/match/cancel"))
+                .andExpect(status().isOk());
+
+        verify(projectRequestService).cancelProjectRequest(any());
+    }
+
+    @Test
+    void cancelProjectRequest_returnsNotFound_whenNoActiveRequest() throws Exception {
+        doThrow(new ProjectRequestNotFoundException(
+                HttpStatus.NOT_FOUND,
+                ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
+                "취소할 수 있는 매칭 요청이 없습니다."
+        )).when(projectRequestService).cancelProjectRequest(any());
+
+        mockMvc.perform(patch("/api/match/cancel"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND))
+                .andExpect(jsonPath("$.message").value("취소할 수 있는 매칭 요청이 없습니다."));
+    }
+
+    // ===== getProjectRequestStatus =====
+
+    @Test
+    void getProjectRequestStatus_returnsOk() throws Exception {
+        when(projectRequestService.getProjectRequestStatus(any()))
+                .thenReturn(new ProjectRequestStatusResponse(Status.WAITING));
+
+        mockMvc.perform(get("/api/match/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("WAITING"));
+    }
+
+    @Test
+    void getProjectRequestStatus_returnsNotFound_whenNoActiveRequest() throws Exception {
+        doThrow(new ProjectRequestNotFoundException(
+                HttpStatus.NOT_FOUND,
+                ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
+                "진행 중인 매칭 요청이 없습니다."
+        )).when(projectRequestService).getProjectRequestStatus(any());
+
+        mockMvc.perform(get("/api/match/status"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND))
+                .andExpect(jsonPath("$.message").value("진행 중인 매칭 요청이 없습니다."));
+    }
+}

--- a/src/test/java/team/po/feature/match/controller/ProjectRequestControllerTest.java
+++ b/src/test/java/team/po/feature/match/controller/ProjectRequestControllerTest.java
@@ -21,17 +21,19 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
+import team.po.common.auth.LoginUserArgumentResolver;
 import team.po.common.jwt.UserPrincipal;
 import team.po.exception.CustomProjectRequestExceptionHandler;
 import team.po.exception.ErrorCodeConstants;
-import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestStatusResponse;
 import team.po.feature.match.enums.Status;
 import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
 import team.po.feature.match.exception.ProjectRequestNotFoundException;
 import team.po.feature.match.service.ProjectRequestService;
+import team.po.feature.user.domain.Users;
 
 import java.util.List;
 
@@ -46,8 +48,26 @@ class ProjectRequestControllerTest {
     @MockitoBean
     private ProjectRequestService projectRequestService;
 
+    @MockitoBean
+    private LoginUserArgumentResolver loginUserArgumentResolver;
+
+    private Users mockUser;
+
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        mockUser = Users.builder()
+                .email("test@email.com")
+                .password("password")
+                .nickname("tester")
+                .level(1)
+                .temperature(50)
+                .build();
+        ReflectionTestUtils.setField(mockUser, "id", 1L);
+
+        // Resolver가 Users 객체를 반환하도록 설정
+        when(loginUserArgumentResolver.supportsParameter(any())).thenReturn(true);
+        when(loginUserArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(mockUser);
+
         UserPrincipal principal = new UserPrincipal(1L, "test@email.com");
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 principal, null, List.of()
@@ -71,7 +91,7 @@ class ProjectRequestControllerTest {
                     """))
                 .andExpect(status().isOk());
 
-        verify(projectRequestService).createProjectRequest(any(), any());
+        verify(projectRequestService).createProjectRequest(any(Users.class), any());
     }
 
     @Test
@@ -91,7 +111,7 @@ class ProjectRequestControllerTest {
                 HttpStatus.CONFLICT,
                 ErrorCodeConstants.PROJECT_REQUEST_ALREADY_EXISTS,
                 "이미 진행 중인 매칭 요청이 있습니다."
-        )).when(projectRequestService).createProjectRequest(any(), any());
+        )).when(projectRequestService).createProjectRequest(any(Users.class), any());
 
         mockMvc.perform(post("/api/match/request")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,7 +130,7 @@ class ProjectRequestControllerTest {
         mockMvc.perform(patch("/api/match/cancel"))
                 .andExpect(status().isOk());
 
-        verify(projectRequestService).cancelProjectRequest(any());
+        verify(projectRequestService).cancelProjectRequest(any(Users.class));
     }
 
     @Test
@@ -119,7 +139,7 @@ class ProjectRequestControllerTest {
                 HttpStatus.NOT_FOUND,
                 ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
                 "취소할 수 있는 매칭 요청이 없습니다."
-        )).when(projectRequestService).cancelProjectRequest(any());
+        )).when(projectRequestService).cancelProjectRequest(any(Users.class));
 
         mockMvc.perform(patch("/api/match/cancel"))
                 .andExpect(status().isNotFound())
@@ -131,7 +151,7 @@ class ProjectRequestControllerTest {
 
     @Test
     void getProjectRequestStatus_returnsOk() throws Exception {
-        when(projectRequestService.getProjectRequestStatus(any()))
+        when(projectRequestService.getProjectRequestStatus(any(Users.class)))
                 .thenReturn(new ProjectRequestStatusResponse(Status.WAITING));
 
         mockMvc.perform(get("/api/match/status"))
@@ -145,7 +165,7 @@ class ProjectRequestControllerTest {
                 HttpStatus.NOT_FOUND,
                 ErrorCodeConstants.PROJECT_REQUEST_NOT_FOUND,
                 "진행 중인 매칭 요청이 없습니다."
-        )).when(projectRequestService).getProjectRequestStatus(any());
+        )).when(projectRequestService).getProjectRequestStatus(any(Users.class));
 
         mockMvc.perform(get("/api/match/status"))
                 .andExpect(status().isNotFound())

--- a/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 
+import org.springframework.test.util.ReflectionTestUtils;
 import team.po.common.auth.LoginUserInfo;
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestDto;
@@ -48,6 +49,7 @@ class ProjectRequestServiceTest {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING, Status.MATCHED))).thenReturn(false);
@@ -75,6 +77,7 @@ class ProjectRequestServiceTest {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING, Status.MATCHED))).thenReturn(true);
@@ -90,6 +93,7 @@ class ProjectRequestServiceTest {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
         ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
@@ -113,6 +117,7 @@ class ProjectRequestServiceTest {
     void cancelProjectRequest_throwsWhenNoActiveRequest() {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
@@ -126,6 +131,7 @@ class ProjectRequestServiceTest {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
         ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
@@ -149,6 +155,7 @@ class ProjectRequestServiceTest {
     void getProjectRequestStatus_throwsWhenNoActiveRequest() {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
@@ -162,6 +169,7 @@ class ProjectRequestServiceTest {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.existsByUserIdAndStatusIn(any(), any())).thenReturn(false);
@@ -175,6 +183,7 @@ class ProjectRequestServiceTest {
     void cancelProjectRequest_throwsWhenMatched() {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         // MATCHED는 findBy 대상이 아니니까 empty 반환

--- a/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
@@ -1,0 +1,164 @@
+package team.po.feature.match.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.po.common.auth.LoginUserInfo;
+import team.po.feature.match.domain.ProjectRequest;
+import team.po.feature.match.dto.ProjectRequestDto;
+import team.po.feature.match.dto.ProjectRequestStatusResponse;
+import team.po.feature.match.enums.Role;
+import team.po.feature.match.enums.Status;
+import team.po.feature.match.exception.ProjectRequestAlreadyExistsException;
+import team.po.feature.match.exception.ProjectRequestNotFoundException;
+import team.po.feature.match.repository.ProjectRequestRepository;
+import team.po.feature.user.domain.Users;
+import team.po.feature.user.exception.UserNotFoundException;
+import team.po.feature.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectRequestServiceTest {
+
+    @Mock
+    private ProjectRequestRepository projectRequestRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ProjectRequestService projectRequestService;
+
+    // ===== createProjectRequest =====
+
+    @Test
+    void createProjectRequest_success() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(false);
+
+        projectRequestService.createProjectRequest(loginUser, dto);
+
+        verify(projectRequestRepository).save(any(ProjectRequest.class));
+    }
+
+    @Test
+    void createProjectRequest_throwsWhenUserNotFound() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
+                .isInstanceOf(UserNotFoundException.class);
+
+        verify(projectRequestRepository, never()).save(any());
+    }
+
+    @Test
+    void createProjectRequest_throwsWhenDuplicateRequest() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(true);
+
+        assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
+                .isInstanceOf(ProjectRequestAlreadyExistsException.class);
+
+        verify(projectRequestRepository, never()).save(any());
+    }
+
+    // ===== cancelProjectRequest =====
+
+    @Test
+    void cancelProjectRequest_success() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
+
+        projectRequestService.cancelProjectRequest(loginUser);
+
+        assertThat(request.getStatus()).isEqualTo(Status.CANCELED);
+    }
+
+    @Test
+    void cancelProjectRequest_throwsWhenUserNotFound() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(loginUser))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    void cancelProjectRequest_throwsWhenNoActiveRequest() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(loginUser))
+                .isInstanceOf(ProjectRequestNotFoundException.class);
+    }
+
+    // ===== getProjectRequestStatus =====
+
+    @Test
+    void getProjectRequestStatus_success() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+        ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
+
+        ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(loginUser);
+
+        assertThat(response.status()).isEqualTo(Status.WAITING);
+    }
+
+    @Test
+    void getProjectRequestStatus_throwsWhenUserNotFound() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectRequestService.getProjectRequestStatus(loginUser))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    void getProjectRequestStatus_throwsWhenNoActiveRequest() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectRequestService.getProjectRequestStatus(loginUser))
+                .isInstanceOf(ProjectRequestNotFoundException.class);
+    }
+}

--- a/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
@@ -52,7 +52,7 @@ class ProjectRequestServiceTest {
         ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING, Status.MATCHED))).thenReturn(false);
+        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(false);
 
         projectRequestService.createProjectRequest(loginUser, dto);
 
@@ -80,7 +80,7 @@ class ProjectRequestServiceTest {
         ReflectionTestUtils.setField(user, "id", loginUser.id());
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING, Status.MATCHED))).thenReturn(true);
+        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(true);
 
         assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
                 .isInstanceOf(ProjectRequestAlreadyExistsException.class);

--- a/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
@@ -17,9 +17,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
-
 import org.springframework.test.util.ReflectionTestUtils;
-import team.po.common.auth.LoginUserInfo;
+
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.dto.ProjectRequestDto;
 import team.po.feature.match.dto.ProjectRequestStatusResponse;
@@ -44,152 +43,106 @@ class ProjectRequestServiceTest {
     @InjectMocks
     private ProjectRequestService projectRequestService;
 
+    private Users createUser(Long id) {
+        Users user = Users.builder()
+                .email("test@email.com")
+                .password("password")
+                .nickname("tester")
+                .level(1)
+                .temperature(50)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    // ========== createProjectRequest ==========
+
     @Test
     void createProjectRequest_success() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = createUser(1L);
         ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(false);
-
-        projectRequestService.createProjectRequest(loginUser, dto);
-
+        projectRequestService.createProjectRequest(user, dto);
         verify(projectRequestRepository).save(any(ProjectRequest.class));
     }
 
     @Test
     void createProjectRequest_throwsWhenUserNotFound() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = createUser(1L);
         ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
-
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
+        assertThatThrownBy(() -> projectRequestService.createProjectRequest(user, dto))
                 .isInstanceOf(UserNotFoundException.class);
-
         verify(projectRequestRepository, never()).save(any());
     }
 
     @Test
     void createProjectRequest_throwsWhenDuplicateRequest() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = createUser(1L);
         ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
         when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(true);
-
-        assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
+        assertThatThrownBy(() -> projectRequestService.createProjectRequest(user, dto))
                 .isInstanceOf(ProjectRequestAlreadyExistsException.class);
-
         verify(projectRequestRepository, never()).save(any());
     }
 
     @Test
-    void cancelProjectRequest_success() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
+    void createProjectRequest_throwsWhenRaceCondition() {
+        Users user = createUser(1L);
+        ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.existsByUserIdAndStatusIn(any(), any())).thenReturn(false);
+        when(projectRequestRepository.save(any())).thenThrow(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> projectRequestService.createProjectRequest(user, dto))
+                .isInstanceOf(ProjectRequestAlreadyExistsException.class);
+    }
+
+    // ========== cancelProjectRequest ==========
+
+    @Test
+    void cancelProjectRequest_success() {
+        Users user = createUser(1L);
+        ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
-
-        projectRequestService.cancelProjectRequest(loginUser);
-
+        projectRequestService.cancelProjectRequest(user);
         assertThat(request.getStatus()).isEqualTo(Status.CANCELED);
     }
 
     @Test
-    void cancelProjectRequest_throwsWhenUserNotFound() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(loginUser))
-                .isInstanceOf(UserNotFoundException.class);
-    }
-
-    @Test
     void cancelProjectRequest_throwsWhenNoActiveRequest() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        Users user = createUser(1L);
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(loginUser))
+        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(user))
                 .isInstanceOf(ProjectRequestNotFoundException.class);
-    }
-
-    @Test
-    void getProjectRequestStatus_success() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
-
-        ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(loginUser);
-
-        assertThat(response.status()).isEqualTo(Status.WAITING);
-    }
-
-    @Test
-    void getProjectRequestStatus_throwsWhenUserNotFound() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> projectRequestService.getProjectRequestStatus(loginUser))
-                .isInstanceOf(UserNotFoundException.class);
-    }
-
-    @Test
-    void getProjectRequestStatus_throwsWhenNoActiveRequest() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> projectRequestService.getProjectRequestStatus(loginUser))
-                .isInstanceOf(ProjectRequestNotFoundException.class);
-    }
-
-    @Test
-    void createProjectRequest_throwsWhenRaceCondition() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-        ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.existsByUserIdAndStatusIn(any(), any())).thenReturn(false);
-        when(projectRequestRepository.save(any())).thenThrow(DataIntegrityViolationException.class);
-
-        assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
-                .isInstanceOf(ProjectRequestAlreadyExistsException.class);
     }
 
     @Test
     void cancelProjectRequest_throwsWhenMatched() {
-        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
-        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
-        ReflectionTestUtils.setField(user, "id", loginUser.id());
-
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        Users user = createUser(1L);
         // MATCHED는 findBy 대상이 아니니까 empty 반환
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(user))
+                .isInstanceOf(ProjectRequestNotFoundException.class);
+    }
 
-        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(loginUser))
+    // ========== getProjectRequestStatus ==========
+
+    @Test
+    void getProjectRequestStatus_success() {
+        Users user = createUser(1L);
+        ProjectRequest request = ProjectRequest.builder().user(user).role(Role.BE).build();
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.of(request));
+        ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(user);
+        assertThat(response.status()).isEqualTo(Status.WAITING);
+    }
+
+    @Test
+    void getProjectRequestStatus_throwsWhenNoActiveRequest() {
+        Users user = createUser(1L);
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> projectRequestService.getProjectRequestStatus(user))
                 .isInstanceOf(ProjectRequestNotFoundException.class);
     }
 }

--- a/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/ProjectRequestServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 
 import team.po.common.auth.LoginUserInfo;
@@ -42,8 +43,6 @@ class ProjectRequestServiceTest {
     @InjectMocks
     private ProjectRequestService projectRequestService;
 
-    // ===== createProjectRequest =====
-
     @Test
     void createProjectRequest_success() {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
@@ -51,7 +50,7 @@ class ProjectRequestServiceTest {
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(false);
+        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING, Status.MATCHED))).thenReturn(false);
 
         projectRequestService.createProjectRequest(loginUser, dto);
 
@@ -78,15 +77,13 @@ class ProjectRequestServiceTest {
         Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
 
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
-        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(true);
+        when(projectRequestRepository.existsByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING, Status.MATCHED))).thenReturn(true);
 
         assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
                 .isInstanceOf(ProjectRequestAlreadyExistsException.class);
 
         verify(projectRequestRepository, never()).save(any());
     }
-
-    // ===== cancelProjectRequest =====
 
     @Test
     void cancelProjectRequest_success() {
@@ -124,8 +121,6 @@ class ProjectRequestServiceTest {
                 .isInstanceOf(ProjectRequestNotFoundException.class);
     }
 
-    // ===== getProjectRequestStatus =====
-
     @Test
     void getProjectRequestStatus_success() {
         LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
@@ -159,6 +154,33 @@ class ProjectRequestServiceTest {
         when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> projectRequestService.getProjectRequestStatus(loginUser))
+                .isInstanceOf(ProjectRequestNotFoundException.class);
+    }
+
+    @Test
+    void createProjectRequest_throwsWhenRaceCondition() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        ProjectRequestDto dto = new ProjectRequestDto(Role.BE, "title", "desc", "mvp");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        when(projectRequestRepository.existsByUserIdAndStatusIn(any(), any())).thenReturn(false);
+        when(projectRequestRepository.save(any())).thenThrow(DataIntegrityViolationException.class);
+
+        assertThatThrownBy(() -> projectRequestService.createProjectRequest(loginUser, dto))
+                .isInstanceOf(ProjectRequestAlreadyExistsException.class);
+    }
+
+    @Test
+    void cancelProjectRequest_throwsWhenMatched() {
+        LoginUserInfo loginUser = new LoginUserInfo(1L, "test@email.com");
+        Users user = Users.builder().email("test@email.com").password("password").nickname("tester").level(1).temperature(50).build();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+        // MATCHED는 findBy 대상이 아니니까 empty 반환
+        when(projectRequestRepository.findByUserIdAndStatusIn(1L, List.of(Status.WAITING, Status.MATCHING))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> projectRequestService.cancelProjectRequest(loginUser))
                 .isInstanceOf(ProjectRequestNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 📌 Related Issue

Closes #9 

## 🚀 Description
- 매칭 요청/취소/상태 조회 API 구현했습니다.
- 매칭 상태는 `WAITING`, `MATCHING`, `MATCHED`, `CANCELED` 네 가지로 정의했습니다.

- 매칭 요청 시 이미 `WAITING` 또는 `MATCHING` 상태인 요청이 있으면 중복 요청을 막도록 처리했습니다.
    - (수정) `MATCHED` 상태인 경우에도 새 매칭을 요청할 수 없도록 처리했습니다. 
    - (수정) 중복 요청 검사와 저장 원자적으로 처리
- 매칭 취소는 DELETE 대신 `CANCELED` status 변경 및 deleteAt 기록하는 방식으로 구현했습니다.
    - (수정) 취소 가능한 상태인지 검증하는 로직 추가함! 
- 매칭 상태 조회는 현재 진행 중인 요청 `WAITING`/`MATCHING`의 status만 내려주도록 구현했습니다. `MATCHED`/`CANCELED`는 일단 404 처리하도록 했는데 변경이 필요할 수도..

## 📢 Review Point
- exception 처리 흐름이나 구조가 맞는지 확인해주십쇼,,
- 혼자 임의로 결정한 부분이 꽤 있어서 API 명세랑 같이 보시면서 피드백 해주세요.

## 📚 Etc (선택)
- 현재 `getActiveUser` 로직을 Service 내에 private 메서드로 구현했는데 어노테이션 쪽에서 기능 추가해주시면 그때 리팩토링 하겠습니다.
- (수정) codex 리뷰 반영하여 `@Transactional` 추가함.