### PR TITLE
[codex] Configure CORS for frontend origins

### DIFF
--- a/src/main/java/team/po/config/SecurityConfig.java
+++ b/src/main/java/team/po/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package team.po.config;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +17,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import jakarta.servlet.http.HttpServletResponse;
 import team.po.common.jwt.JwtAuthenticationFilter;
@@ -32,6 +36,7 @@ public class SecurityConfig {
 	) throws Exception {
 		http
 			.httpBasic(AbstractHttpConfigurer::disable)
+			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 			.csrf(AbstractHttpConfigurer::disable)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.logout(AbstractHttpConfigurer::disable)
@@ -50,6 +55,25 @@ public class SecurityConfig {
 			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.setAllowedOrigins(List.of(
+			"http://localhost:5173",
+			"http://localhost:3000",
+			"https://team-po.cloud"
+		));
+		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+		configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+		configuration.setExposedHeaders(List.of("Authorization"));
+		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
 	}
 
 	@Bean


### PR DESCRIPTION
## Summary
- Enable Spring Security CORS handling in `SecurityConfig`
- Allow frontend origins for local development and production
- Permit common API methods and request headers used by the client

## Why
The frontend needs to call the backend API from browser origins during local testing and from the production domain. Without an explicit CORS configuration, preflight and authenticated browser requests can be rejected before reaching controllers.

## Allowed origins
- `http://localhost:5173`
- `http://localhost:3000`
- `https://team-po.cloud`

## Validation
- `./gradlew test`

Closes #38