### PR TITLE
Refactor : www.team-po.cloud CORS 허용 Origin 추가

### DIFF
--- a/src/main/java/team/po/config/SecurityConfig.java
+++ b/src/main/java/team/po/config/SecurityConfig.java
@@ -71,7 +71,8 @@ public class SecurityConfig {
 		configuration.setAllowedOrigins(List.of(
 			"http://localhost:5173",
 			"http://localhost:3000",
-			"https://team-po.cloud"
+			"https://team-po.cloud",
+			"https://www.team-po.cloud"
 		));
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));


### PR DESCRIPTION
## 📌 Related Issue

Closes #48

## 🚀 Description

- CORS 허용 Origin에 `https://www.team-po.cloud`를 추가했습니다.
- 기존 `https://team-po.cloud` 및 로컬 개발 Origin은 그대로 유지했습니다.

### 왜 필요한가요?

브라우저의 CORS 정책에서 Origin은 `프로토콜 + 도메인 + 포트` 조합으로 판단됩니다. 그래서 `https://team-po.cloud`와 `https://www.team-po.cloud`는 사용자가 보기에는 같은 서비스 주소처럼 보여도, 브라우저 입장에서는 서로 다른 Origin입니다.

백엔드 CORS 허용 목록에 `https://team-po.cloud`만 있으면, 프론트엔드가 `https://www.team-po.cloud`에서 API를 호출할 때 preflight 요청 또는 인증이 포함된 요청이 컨트롤러에 도달하기 전에 브라우저/보안 필터 단계에서 차단될 수 있습니다. 이 경우 서버 API 자체는 정상이어도 프론트 화면에서는 로그인, 회원가입, 데이터 조회 같은 요청이 CORS 에러로 실패할 수 있습니다.

이번 변경은 모든 Origin을 넓게 허용하지 않고, 운영에서 실제로 사용하는 `www` 서브도메인만 명시적으로 추가합니다. `allowCredentials(true)`를 사용하고 있기 때문에 와일드카드(`*`)로 푸는 방식보다 필요한 Origin만 열어두는 방식이 더 안전합니다.

## 📢 Review Point

- `https://www.team-po.cloud`에서 브라우저 요청 시 CORS preflight 및 인증 요청이 정상 허용되는지 확인 부탁드립니다.
- 기존 `https://team-po.cloud`, localhost 개발 환경 요청이 그대로 유지되는지 확인 부탁드립니다.

## 📚 Etc (선택)

- `./gradlew test` 통과