### PR TITLE
refactor : ec2 구조에 맞게 배포 flow 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,14 @@ jobs:
             AWS_REGION="${{ secrets.AWS_REGION }}"
             CLOUDWATCH_LOG_GROUP_NAME="/aws/teampo/dev/api"
             ECR_REGISTRY="${ECR_REPOSITORY_URL%/*}"
+            API_ENV_FILE="/opt/teampo/api.env"
+            API_HOST_PORT="8080"
+            API_CONTAINER_PORT="8080"
+            API_HEALTH_URL="http://127.0.0.1:${API_HOST_PORT}/swagger-ui/index.html"
+            CANDIDATE_HOST_PORT="18080"
+            CANDIDATE_HEALTH_URL="http://127.0.0.1:${CANDIDATE_HOST_PORT}/swagger-ui/index.html"
+            NGINX_CONTAINER_NAME="team-po-nginx"
+            NGINX_CONF_PATH="/home/ec2-user/proxy-stack/nginx/conf.d/default.conf"
 
             wait_for_http() {
               url="$1"
@@ -79,24 +87,37 @@ jobs:
                 --name teampo-api \
                 --restart unless-stopped \
                 --network teampo \
-                --env-file /opt/teampo/api.env \
+                --env-file "$API_ENV_FILE" \
                 --log-driver=awslogs \
                 --log-opt awslogs-region="$AWS_REGION" \
                 --log-opt awslogs-group="$CLOUDWATCH_LOG_GROUP_NAME" \
                 --log-opt awslogs-stream=api \
-                -p 80:8080 \
+                -p "127.0.0.1:${API_HOST_PORT}:${API_CONTAINER_PORT}" \
                 "$image"
+            }
+
+            ensure_nginx_proxy() {
+              if ! sudo docker inspect "$NGINX_CONTAINER_NAME" >/dev/null 2>&1; then
+                echo "Nginx container '$NGINX_CONTAINER_NAME' is not running or does not exist."
+                return 1
+              fi
+
+              sudo docker network connect teampo "$NGINX_CONTAINER_NAME" 2>/dev/null || true
+              sudo test -r "$NGINX_CONF_PATH"
+              sudo sed -i.bak -E "s#proxy_pass http://[^;]+;#proxy_pass http://teampo-api:${API_CONTAINER_PORT};#" "$NGINX_CONF_PATH"
+              sudo docker exec "$NGINX_CONTAINER_NAME" nginx -t
+              sudo docker exec "$NGINX_CONTAINER_NAME" nginx -s reload
             }
 
             rollback_api() {
               if [ -n "$PREVIOUS_IMAGE_ID" ]; then
                 sudo docker rm -f teampo-api 2>/dev/null || true
                 run_api_container "$PREVIOUS_IMAGE_ID"
-                wait_for_http http://localhost/swagger-ui/index.html
+                wait_for_http "$API_HEALTH_URL"
               fi
             }
 
-            sudo test -r /opt/teampo/api.env
+            sudo test -r "$API_ENV_FILE"
             sudo docker network create teampo 2>/dev/null || true
 
             aws ecr get-login-password --region "$AWS_REGION" \
@@ -111,15 +132,15 @@ jobs:
               --name teampo-api-candidate \
               --restart no \
               --network teampo \
-              --env-file /opt/teampo/api.env \
+              --env-file "$API_ENV_FILE" \
               --log-driver=awslogs \
               --log-opt awslogs-region="$AWS_REGION" \
               --log-opt awslogs-group="$CLOUDWATCH_LOG_GROUP_NAME" \
               --log-opt awslogs-stream=api-candidate \
-              -p 127.0.0.1:18080:8080 \
+              -p "127.0.0.1:${CANDIDATE_HOST_PORT}:${API_CONTAINER_PORT}" \
               "${ECR_REPOSITORY_URL}:latest"
 
-            if ! wait_for_http http://127.0.0.1:18080/swagger-ui/index.html; then
+            if ! wait_for_http "$CANDIDATE_HEALTH_URL"; then
               sudo docker ps -a --filter name=teampo-api-candidate
               sudo docker rm -f teampo-api-candidate 2>/dev/null || true
               exit 1
@@ -133,7 +154,18 @@ jobs:
               exit 1
             fi
 
-            if ! wait_for_http http://localhost/swagger-ui/index.html; then
+            if ! wait_for_http "$API_HEALTH_URL"; then
+              sudo docker ps -a --filter name=teampo-api
+              rollback_api
+              exit 1
+            fi
+
+            if ! ensure_nginx_proxy; then
+              rollback_api
+              exit 1
+            fi
+
+            if ! wait_for_http https://api.team-po.cloud/swagger-ui/index.html; then
               sudo docker ps -a --filter name=teampo-api
               rollback_api
               exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,10 +103,10 @@ jobs:
               fi
 
               sudo docker network connect teampo "$NGINX_CONTAINER_NAME" 2>/dev/null || true
-              sudo test -r "$NGINX_CONF_PATH"
-              sudo sed -i.bak -E "s#proxy_pass http://[^;]+;#proxy_pass http://teampo-api:${API_CONTAINER_PORT};#" "$NGINX_CONF_PATH"
-              sudo docker exec "$NGINX_CONTAINER_NAME" nginx -t
-              sudo docker exec "$NGINX_CONTAINER_NAME" nginx -s reload
+              sudo test -r "$NGINX_CONF_PATH" || return 1
+              sudo sed -i.bak -E "s#proxy_pass http://[^;]+;#proxy_pass http://teampo-api:${API_CONTAINER_PORT};#" "$NGINX_CONF_PATH" || return 1
+              sudo docker exec "$NGINX_CONTAINER_NAME" nginx -t || return 1
+              sudo docker exec "$NGINX_CONTAINER_NAME" nginx -s reload || return 1
             }
 
             rollback_api() {

--- a/infra/envs/dev/.terraform.lock.hcl
+++ b/infra/envs/dev/.terraform.lock.hcl
@@ -43,23 +43,3 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version     = "4.2.1"
-  constraints = ">= 4.0.0, < 5.0.0"
-  hashes = [
-    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
-    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
-    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
-    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
-    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
-    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
-    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
-    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
-    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
-    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
-    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
-    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-  ]
-}

--- a/infra/envs/dev/README.md
+++ b/infra/envs/dev/README.md
@@ -47,5 +47,5 @@ AWS_PROFILE=teampo-terraform terraform apply -var 'db_password=<secure-password>
 - `app_ingress_cidr_blocks` 기본값은 dev 편의를 위해 전체 공개입니다. 운영 전에는 필요한 CIDR로 제한하세요.
 - `ssh_ingress_cidr_blocks` 기본값도 전체 공개입니다. 실제 적용 전에는 본인 IP `/32`로 제한하는 것을 권장합니다.
 - S3 프로필 이미지 버킷은 객체 조회(`s3:GetObject`)를 public으로 허용합니다. 업로드/삭제 권한은 public으로 열지 않습니다.
-- EC2 security group은 외부 HTTP 포트 `80`과 HTTPS 포트 `443`을 엽니다. API 컨테이너는 배포 시 `-p 80:8080`으로 실행하고, HTTPS는 EC2 내부 reverse proxy가 인증서를 처리한 뒤 API로 프록시하도록 구성하세요.
+- EC2 security group은 외부 HTTP 포트 `80`과 HTTPS 포트 `443`을 엽니다. Nginx reverse proxy가 외부 포트를 점유하고, API 컨테이너는 host `127.0.0.1:8080`과 Docker `teampo` 네트워크에만 노출한 뒤 Nginx가 `teampo-api:8080`으로 프록시하도록 구성하세요.
 - RDS master password는 `db_password` 변수로 주입합니다. `terraform.tfvars`는 Git에 커밋하지 마세요.

--- a/infra/envs/dev/compute.tf
+++ b/infra/envs/dev/compute.tf
@@ -19,7 +19,7 @@ data "aws_ami" "amazon_linux_2023" {
 }
 
 resource "aws_instance" "app" {
-  ami                         = data.aws_ami.amazon_linux_2023.id
+  ami                         = coalesce(var.app_ami_id, data.aws_ami.amazon_linux_2023.id)
   instance_type               = var.app_instance_type
   subnet_id                   = local.app_subnet_id
   vpc_security_group_ids      = [aws_security_group.app.id]

--- a/infra/envs/dev/compute.tf
+++ b/infra/envs/dev/compute.tf
@@ -48,4 +48,8 @@ resource "aws_instance" "app" {
   tags = {
     Name = "${local.name_prefix}-api"
   }
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -62,9 +62,9 @@ variable "app_key_name" {
 }
 
 variable "app_ami_id" {
-  description = "API EC2에 사용할 AMI ID. null이면 최신 Amazon Linux 2023 AMI를 사용하므로 기존 인스턴스 교체가 발생할 수 있다."
+  description = "API EC2 최초 생성 시 사용할 AMI ID. null이면 현재 리전의 최신 Amazon Linux 2023 AMI를 조회한다. 생성 이후 AMI 변경은 우발적인 EC2 교체를 막기 위해 무시한다."
   type        = string
-  default     = "ami-0c003e98ceffee43e"
+  default     = null
 }
 
 variable "app_instance_type" {

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -39,7 +39,7 @@ variable "log_retention_days" {
 }
 
 variable "app_port" {
-  description = "EC2에서 외부에 열어둘 HTTP 포트. API 컨테이너는 host 80 -> container 8080으로 매핑한다."
+  description = "EC2에서 외부에 열어둘 HTTP 포트. 현재는 Nginx reverse proxy가 외부 80/443을 점유하고 API는 localhost:8080 및 Docker teampo 네트워크에만 노출한다."
   type        = number
   default     = 80
 }
@@ -59,6 +59,12 @@ variable "ssh_ingress_cidr_blocks" {
 variable "app_key_name" {
   description = "EC2 SSH 접속에 사용할 AWS key pair 이름. null이면 key pair를 연결하지 않는다."
   type        = string
+}
+
+variable "app_ami_id" {
+  description = "API EC2에 사용할 AMI ID. null이면 최신 Amazon Linux 2023 AMI를 사용하므로 기존 인스턴스 교체가 발생할 수 있다."
+  type        = string
+  default     = "ami-0c003e98ceffee43e"
 }
 
 variable "app_instance_type" {


### PR DESCRIPTION
## 📌 Related Issue


## 🚀 Description

  - 현재 EC2 구조에 맞게 배포 workflow를 수정했습니다.
  - API 컨테이너가 host 80 포트를 직접 점유하지 않고 `127.0.0.1:8080`으로만 바인딩되도록 변경했습니다.
  - Nginx(`team-po-nginx`)가 외부 80/443 요청을 받고 `teampo-api:8080`으로 프록시하도록 배포 중 설정을 갱신하게 했습니다.
  - 배포 헬스체크를 candidate 컨테이너, 최종 API 컨테이너, 외부 HTTPS 엔드포인트 순서로 확인하도록 정리했습니다.
  - 최신 AMI 조회로 인해 Terraform plan 시 EC2 replacement가 발생하지 않도록 현재 EC2 AMI ID를 기본값으로 고정했습니다.

 ## 📢 Review Point


 ## 📚 Etc (선택)

  - 현재 EC2에서는 Nginx가 host 80/443을 이미 사용 중이라 기존 `-p 80:8080` 방식으로 배포하면 포트 충돌이 발생할 수 있습니다.
  - Terraform plan에서 최신 Amazon Linux AMI 변경으로 `aws_instance.app` replacement가 발생하는 것을 확인했고, 이를 방지하기 위해 현재 인스턴스의 AMI를 기본값으로 고정했습니다.
