### PR TITLE
Fix: 매칭 도메인 detached 엔티티 문제 수정

### DIFF
--- a/src/main/java/team/po/feature/match/service/MatchScheduler.java
+++ b/src/main/java/team/po/feature/match/service/MatchScheduler.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.slf4j.MDC;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -43,29 +42,26 @@ public class MatchScheduler {
 	@Scheduled(fixedDelay = 60_000) // 1분마다 실행
 	public void runMatchingCycle() {
 		String cycleId = UUID.randomUUID().toString().substring(0, 8);
-		MDC.put("cycleId", cycleId);
 
 		try {
-			log.info("매칭 사이클 시작");
+			log.info("[{}] 매칭 사이클 시작", cycleId);
 			// 1. waiting pool 로드
 			Map<Role, List<ProjectRequest>> waitingPool = loadWaitingMemberPool();
 			// 2. 빈자리 충원 프로세스 (기존 세션 우선)
-			processVacancies(waitingPool);
+			processVacancies(waitingPool, cycleId);
 			// 3. 신규 매칭 프로세스
-			processNewMatching(waitingPool);
+			processNewMatching(waitingPool, cycleId);
 
-			log.info("매칭 사이클 완료");
+			log.info("[{}] 매칭 사이클 완료", cycleId);
 		} catch (Exception e) {
-			log.error("매칭 사이클 실행 중 예외 발생", e);
-		} finally {
-			MDC.remove("cycleId");
+			log.error("[{}] 매칭 사이클 실행 중 예외 발생", cycleId, e);
 		}
 	}
 
 	// 신규 매칭 세션 생성
-	private void processNewMatching(Map<Role, List<ProjectRequest>> waitingPool) {
+	private void processNewMatching(Map<Role, List<ProjectRequest>> waitingPool, String cycleId) {
 		List<ProjectRequest> hosts = projectRequestRepository.findWaitingHosts(PageRequest.of(0, HOST_BATCH_LIMIT));
-		log.debug("New Host Candidate: {}명", hosts.size());
+		log.debug("[{}] New Host Candidate: {}명", cycleId, hosts.size());
 
 		for (ProjectRequest host : hosts) {
 			try {
@@ -86,20 +82,20 @@ public class MatchScheduler {
 					removeMatchedFromPool(waitingPool, matchedIds);
 				});
 			} catch (Exception e) {
-				log.error("신규 매칭 세션 생성 실패: hostId={}", host.getId(), e);
+				log.error("[{}] 신규 매칭 세션 생성 실패: hostId={}", cycleId, host.getId(), e);
 			}
 		}
 	}
 
 	// 기존 세션 빈자리 충원
-	private void processVacancies(Map<Role, List<ProjectRequest>> waitingPool) {
+	private void processVacancies(Map<Role, List<ProjectRequest>> waitingPool, String cycleId) {
 		List<MatchingSession> activeSessions = matchingSessionRepository.findAllActive();
 
 		for (MatchingSession session : activeSessions) {
 			try {
 				fillSessionVacancy(session, waitingPool);
 			} catch (Exception e) {
-				log.error("빈자리 충원 실패: sessionId={}", session.getId(), e);
+				log.error("[{}] 빈자리 충원 실패: sessionId={}", cycleId, session.getId(), e);
 			}
 		}
 	}

--- a/src/main/java/team/po/feature/match/service/MatchScheduler.java
+++ b/src/main/java/team/po/feature/match/service/MatchScheduler.java
@@ -72,7 +72,11 @@ public class MatchScheduler {
 				MatchingContext context = new MatchingContext(host, waitingPool, blacklist);
 				matchingStrategy.findTeamCandidates(context).ifPresent(result -> {
 					List<ProjectRequest> candidates = result.selectedCandidates();
-					matchService.createMatchingSession(host, candidates);
+
+					matchService.createMatchingSession(
+						host.getId(),
+						candidates.stream().map(ProjectRequest::getId).toList()
+					);
 
 					// 매칭된 인원은 pool에서 제거 (사이클 내 중복 매칭 방지)
 					Set<Long> matchedIds = candidates.stream()
@@ -148,7 +152,7 @@ public class MatchScheduler {
 					break;
 
 				ProjectRequest selected = candidate.get();
-				matchService.fillVacancy(session.getId(), role, selected);
+				matchService.fillVacancy(session.getId(), role, selected.getId());
 
 				// 트랜잭션 완료 후 pool 및 blacklist 업데이트
 				blacklist.add(selected.getUser().getId());

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -49,8 +49,18 @@ public class MatchService {
 
 	// 신규 매칭 세션 생성
 	@Transactional
-	public void createMatchingSession(ProjectRequest host, List<ProjectRequest> members) {
-		// 1. 매칭 세션 생성 및 저장
+	public void createMatchingSession(Long hostRequestId, List<Long> memberRequestIds) {
+		// 1-1. ProjectRequest 재조회 (managed 상태)
+		ProjectRequest host = projectRequestRepository.findById(hostRequestId)
+			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND));
+		List<ProjectRequest> members = projectRequestRepository.findAllById(memberRequestIds);
+
+		if (members.size() != memberRequestIds.size()) {
+			log.error("매칭 멤버 ProjectRequest 조회 누락");
+			throw new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND);
+		}
+
+		// 1-2. 매칭 세션 생성 및 저장
 		MatchingSession session = matchingSessionRepository.save(MatchingSession.create());
 
 		// 2. Host 정보 등록 및 요청 상태 변경 (WAITING -> MATCHING)
@@ -81,11 +91,15 @@ public class MatchService {
 
 	// 기존 매칭 세션의 빈자리 채우기
 	@Transactional
-	public void fillVacancy(Long sessionId, Role role, ProjectRequest candidate) {
+	public void fillVacancy(Long sessionId, Role role, Long candidateRequestId) {
 		// Session: PESSIMISTIC_LOCK
 		MatchingSession session = matchingSessionRepository
 			.findByIdWithLock(sessionId)
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
+
+		// ProjectRequest 재조회 (managed 상태)
+		ProjectRequest candidate = projectRequestRepository.findById(candidateRequestId)
+			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND));
 
 		if (candidate.getStatus() != Status.WAITING) {
 			log.debug("후보 상태 변경됨 - 빈자리 충원 스킵: sessionId={}, candidateUserId={}",

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -61,6 +61,8 @@ public class ProjectRequestService {
 				.projectMvp(request.projectMvp())
 				.build();
 			projectRequestRepository.save(projectRequest);
+			log.info("매칭 요청 생성 완료. userId: {}, projectRequestId: {}, role: {}",
+				user.getId(), projectRequest.getId(), projectRequest.getRole());
 		} catch (DataIntegrityViolationException e) { // 동시 요청 Race Condition
 			throw new ApplicationException(ErrorCode.PROJECT_REQUEST_ALREADY_EXISTS);
 		}

--- a/src/test/java/team/po/feature/match/service/MatchServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/MatchServiceTest.java
@@ -508,15 +508,16 @@ class MatchServiceTest {
 
 		ProjectRequest candidatePr = createMemberRequest(candidateUser);
 		ReflectionTestUtils.setField(candidatePr, "id", 2L);
-		// candidatePr은 WAITING 상태 (생성 시 기본값)
 
 		when(matchingSessionRepository.findByIdWithLock(42L))
 			.thenReturn(Optional.of(session));
+		when(projectRequestRepository.findById(2L))  // ← 추가
+			.thenReturn(Optional.of(candidatePr));
 
 		// When
-		matchService.fillVacancy(42L, Role.FRONTEND, candidatePr);
+		matchService.fillVacancy(42L, Role.FRONTEND, candidatePr.getId());
 
-		// Then: 후보가 MATCHING 상태로 전환되고 이벤트 발행됨
+		// Then
 		assertThat(candidatePr.getStatus()).isEqualTo(Status.MATCHING);
 		verify(matchingMemberRepository).save(any(MatchingMember.class));
 
@@ -528,25 +529,26 @@ class MatchServiceTest {
 
 	@Test
 	void fillVacancy_skip_whenCandidateNotWaiting() {
-		// Given: 락 잡는 사이 후보가 cancel하여 CANCELED 상태로 변경됨
 		Users candidateUser = createUser(2L);
 		MatchingSession session = createSession(42L);
 
 		ProjectRequest candidatePr = createMemberRequest(candidateUser);
 		ReflectionTestUtils.setField(candidatePr, "id", 2L);
 		candidatePr.startMatching();
-		candidatePr.cancel();  // WAITING → MATCHING → CANCELED
+		candidatePr.cancel();
 
 		when(matchingSessionRepository.findByIdWithLock(42L))
 			.thenReturn(Optional.of(session));
+		when(projectRequestRepository.findById(2L))  // ← 추가
+			.thenReturn(Optional.of(candidatePr));
 
 		// When
-		matchService.fillVacancy(42L, Role.FRONTEND, candidatePr);
+		matchService.fillVacancy(42L, Role.FRONTEND, candidatePr.getId());
 
-		// Then: 멤버 INSERT도, 이벤트 발행도 일어나지 않음
+		// Then
 		verify(matchingMemberRepository, never()).save(any(MatchingMember.class));
 		verify(eventPublisher, never()).publishEvent(any());
-		assertThat(candidatePr.getStatus()).isEqualTo(Status.CANCELED);  // 상태 그대로
+		assertThat(candidatePr.getStatus()).isEqualTo(Status.CANCELED);
 	}
 
 	@Test
@@ -560,7 +562,7 @@ class MatchServiceTest {
 			.thenReturn(Optional.empty());
 
 		// When & Then
-		assertThatThrownBy(() -> matchService.fillVacancy(42L, Role.FRONTEND, candidatePr))
+		assertThatThrownBy(() -> matchService.fillVacancy(42L, Role.FRONTEND, candidatePr.getId()))
 			.isInstanceOf(ApplicationException.class);
 
 		verify(matchingMemberRepository, never()).save(any(MatchingMember.class));


### PR DESCRIPTION
## 📌 Related Issue
Closes #65

## 🚀 Description
- 매칭 세션 생성/충원 시 ProjectRequest 상태 전이가 누락되어 발생하던 세션 중복 생성 문제를 수정했습니다.

### Root Cause
`MatchScheduler`가 트랜잭션 밖에서 조회한 `ProjectRequest`를 `MatchService`에 넘기면, 서비스 트랜잭션 내부에서 detached 상태이므로 `startMatching()` 호출 시 dirty checking이 동작하지 않아 UPDATE가 발생하지 않았습니다. 상태가 WAITING으로 유지되어 다음 사이클에 재조회 → 세션 중복 생성으로 이어졌습니다.

### Changes
- `createMatchingSession` 시그니처를 ID 기반으로 변경 (`hostRequestId`, `memberRequestIds`)
- `fillVacancy` 시그니처를 ID 기반으로 변경 (`candidateRequestId`)
- 서비스 트랜잭션 내부에서 `ProjectRequest` 재조회로 managed 상태 보장
- `MatchScheduler` 호출부 수정 및 멤버 누락 검증 추가


## 📢 Review Point

<!-- 리뷰어가 중점적으로 봐야 할 내용을 작성해 주세요. -->

## 📚 Etc (선택)
```
Hibernate: 
    update
        project_request 
    set
        canceled_at=?,
        project_description=?,
        project_mvp=?,
        project_title=?,
        role=?,
        status=?,
        user_id=? 
    where
        id=?
2026-05-17T22:29:34.925+09:00 DEBUG 358633 --- [         task-4] t.p.f.m.event.MatchNotificationListener  : 그룹 생성 완료 이벤트 수신: matchSessionId=1, projectGroupId=1
```
- ProjectRequest `MATCHED`로 바뀌고 `ProjectGroup` 조회 성공까지 확인했습니다