### PR TITLE
Refactor: 매칭 관련 API 응답 및 파라미터 구조 개선

### DIFF
--- a/src/main/java/team/po/feature/match/controller/MatchController.java
+++ b/src/main/java/team/po/feature/match/controller/MatchController.java
@@ -32,12 +32,11 @@ public class MatchController {
 	}
 
 	@Operation(summary = "매칭 프로젝트 정보 조회 API")
-	@GetMapping("/{matchId}/project")
+	@GetMapping("/project")
 	public ResponseEntity<MatchProjectResponse> getMatchProject(
-		@PathVariable Long matchId,
 		@Parameter(hidden = true) @LoginUser Users user
 	) {
-		MatchProjectResponse response = matchService.getMatchProject(matchId, user);
+		MatchProjectResponse response = matchService.getMatchProject(user);
 		return ResponseEntity.ok().body(response);
 	}
 

--- a/src/main/java/team/po/feature/match/controller/MatchController.java
+++ b/src/main/java/team/po/feature/match/controller/MatchController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import team.po.common.auth.LoginUser;
 import team.po.feature.match.dto.MatchMemberResponse;
@@ -25,7 +26,7 @@ public class MatchController {
 	@GetMapping("/{matchId}/members")
 	public ResponseEntity<MatchMemberResponse> getMatchMembers(
 		@PathVariable Long matchId,
-		@LoginUser Users user
+		@Parameter(hidden = true) @LoginUser Users user
 	) {
 		MatchMemberResponse response = matchService.getMatchMembers(matchId, user);
 		return ResponseEntity.ok().body(response);
@@ -35,7 +36,7 @@ public class MatchController {
 	@GetMapping("/{matchId}/project")
 	public ResponseEntity<MatchProjectResponse> getMatchProject(
 		@PathVariable Long matchId,
-		@LoginUser Users user
+		@Parameter(hidden = true) @LoginUser Users user
 	) {
 		MatchProjectResponse response = matchService.getMatchProject(matchId, user);
 		return ResponseEntity.ok().body(response);
@@ -45,7 +46,7 @@ public class MatchController {
 	@PostMapping("/{matchId}/accept")
 	public ResponseEntity<Void> accept(
 		@PathVariable Long matchId,
-		@LoginUser Users user
+		@Parameter(hidden = true) @LoginUser Users user
 	) {
 		matchService.accept(matchId, user);
 		return ResponseEntity.ok().build();
@@ -55,7 +56,7 @@ public class MatchController {
 	@PostMapping("/{matchId}/reject")
 	public ResponseEntity<Void> reject(
 		@PathVariable Long matchId,
-		@LoginUser Users user
+		@Parameter(hidden = true) @LoginUser Users user
 	) {
 		matchService.reject(matchId, user);
 		return ResponseEntity.ok().build();
@@ -63,7 +64,7 @@ public class MatchController {
 
 	@Operation(summary = "매칭 취소 API")
 	@PostMapping(value = "/cancel")
-	public ResponseEntity<Void> cancel(@LoginUser Users user) {
+	public ResponseEntity<Void> cancel(@Parameter(hidden = true) @LoginUser Users user) {
 		matchService.cancel(user);
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/team/po/feature/match/controller/MatchController.java
+++ b/src/main/java/team/po/feature/match/controller/MatchController.java
@@ -23,12 +23,11 @@ public class MatchController {
 	private final MatchService matchService;
 
 	@Operation(summary = "매칭 멤버 조회 API")
-	@GetMapping("/{matchId}/members")
+	@GetMapping("/members")
 	public ResponseEntity<MatchMemberResponse> getMatchMembers(
-		@PathVariable Long matchId,
 		@Parameter(hidden = true) @LoginUser Users user
 	) {
-		MatchMemberResponse response = matchService.getMatchMembers(matchId, user);
+		MatchMemberResponse response = matchService.getMatchMembers(user);
 		return ResponseEntity.ok().body(response);
 	}
 

--- a/src/main/java/team/po/feature/match/controller/MatchController.java
+++ b/src/main/java/team/po/feature/match/controller/MatchController.java
@@ -41,22 +41,20 @@ public class MatchController {
 	}
 
 	@Operation(summary = "매칭 수락 API")
-	@PostMapping("/{matchId}/accept")
+	@PostMapping("/accept")
 	public ResponseEntity<Void> accept(
-		@PathVariable Long matchId,
 		@Parameter(hidden = true) @LoginUser Users user
 	) {
-		matchService.accept(matchId, user);
+		matchService.accept(user);
 		return ResponseEntity.ok().build();
 	}
 
 	@Operation(summary = "매칭 거절 API")
-	@PostMapping("/{matchId}/reject")
+	@PostMapping("/reject")
 	public ResponseEntity<Void> reject(
-		@PathVariable Long matchId,
 		@Parameter(hidden = true) @LoginUser Users user
 	) {
-		matchService.reject(matchId, user);
+		matchService.reject(user);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
+++ b/src/main/java/team/po/feature/match/controller/ProjectRequestController.java
@@ -1,6 +1,5 @@
 package team.po.feature.match.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.po.common.auth.LoginUser;
@@ -25,7 +25,7 @@ public class ProjectRequestController {
 
 	@Operation(summary = "매칭 요청 API")
 	@PostMapping(value = "/request")
-	public ResponseEntity<Void> createProjectRequest(@LoginUser Users user,
+	public ResponseEntity<Void> createProjectRequest(@Parameter(hidden = true) @LoginUser Users user,
 		@Valid @RequestBody ProjectRequestDto request) {
 		projectRequestService.createProjectRequest(user, request);
 		return ResponseEntity.ok().build();
@@ -33,7 +33,8 @@ public class ProjectRequestController {
 
 	@Operation(summary = "매칭 상태 조회 API")
 	@GetMapping(value = "/status")
-	public ResponseEntity<ProjectRequestStatusResponse> getProjectRequestStatus(@LoginUser Users user) {
+	public ResponseEntity<ProjectRequestStatusResponse> getProjectRequestStatus(
+		@Parameter(hidden = true) @LoginUser Users user) {
 		ProjectRequestStatusResponse response = projectRequestService.getProjectRequestStatus(user);
 		return ResponseEntity.ok().body(response);
 	}

--- a/src/main/java/team/po/feature/match/dto/MatchMemberResponse.java
+++ b/src/main/java/team/po/feature/match/dto/MatchMemberResponse.java
@@ -5,7 +5,6 @@ import java.util.List;
 import team.po.feature.match.enums.Role;
 
 public record MatchMemberResponse(
-	Long matchId,
 	List<MemberDto> members
 ) {
 	public record MemberDto(

--- a/src/main/java/team/po/feature/match/dto/MatchProjectResponse.java
+++ b/src/main/java/team/po/feature/match/dto/MatchProjectResponse.java
@@ -1,7 +1,6 @@
 package team.po.feature.match.dto;
 
 public record MatchProjectResponse(
-	Long matchId,
 	String projectTitle,
 	String projectDescription,
 	String projectMvp

--- a/src/main/java/team/po/feature/match/dto/ProjectRequestStatusResponse.java
+++ b/src/main/java/team/po/feature/match/dto/ProjectRequestStatusResponse.java
@@ -1,9 +1,10 @@
 package team.po.feature.match.dto;
 
+import team.po.feature.match.enums.Role;
 import team.po.feature.match.enums.Status;
 
 public record ProjectRequestStatusResponse(
 	Status status,
-	Long matchId
+	Role role
 ) {
 }

--- a/src/main/java/team/po/feature/match/event/MatchNotificationListener.java
+++ b/src/main/java/team/po/feature/match/event/MatchNotificationListener.java
@@ -31,8 +31,7 @@ public class MatchNotificationListener {
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleMatchAcceptedEvent(MatchAcceptedEvent event) {
-		log.debug("매칭 수락 이벤트 수신: matchSessionId={}, acceptedUserId={}",
-			event.matchSessionId(), event.acceptedUserId());
+		log.debug("매칭 수락 이벤트 수신: matchSessionId={}", event.matchSessionId());
 		// TODO: 수락 알림 (나머지 멤버 또는 이미 수락한 멤버)
 	}
 
@@ -47,32 +46,30 @@ public class MatchNotificationListener {
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleMatchRejectedEvent(MatchRejectedEvent event) {
-		log.debug("매칭 거절 이벤트 수신: matchSessionId={}, rejectedUserId={}",
-			event.matchSessionId(), event.rejectedUserId());
+		log.debug("매칭 거절 이벤트 수신: matchSessionId={}", event.matchSessionId());
 		// TODO: 나머지 멤버에게 (또는 팀장에게) 거절 및 재매칭 예정 알림
 	}
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleMatchMemberCanceledEvent(MatchMemberCanceledEvent event) {
-		log.debug("매칭 취소 이벤트 수신: matchSessionId={}, canceledUserId={}",
-			event.matchSessionId(), event.canceledUserId());
+		log.debug("매칭 취소 이벤트 수신: matchSessionId={}", event.matchSessionId());
 		// TODO: 나머지 멤버에게 (또는 팀장에게) 취소 및 재매칭 예정 알림
 	}
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleMatchSessionDisbandedEvent(MatchSessionDisbandedEvent event) {
-		log.debug("매칭 세션 해산 이벤트 수신: matchSessionId={}, restoreMemberIds={}",
-			event.matchSessionId(), event.restoreMemberUserIds());
+		log.debug("매칭 세션 해산 이벤트 수신: matchSessionId={}, restoredCount={}",
+			event.matchSessionId(), event.restoreMemberUserIds().size());
 		// TODO: WAITING 복귀 멤버들에게 매칭 재진행 알림
 	}
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleMatchOrphanSessionCleanedEvent(MatchOrphanSessionCleanedEvent event) {
-		log.debug("호스트 누락 세션 정리 이벤트 수신: matchSessionId={}, restoreMemberIds={}",
-			event.matchSessionId(), event.restoreMemberUserIds());
+		log.debug("호스트 누락 세션 정리 이벤트 수신: matchSessionId={}, restoredCount={}",
+			event.matchSessionId(), event.restoreMemberUserIds().size());
 		// TODO: WAITING 복귀 멤버들에게 매칭 재진행 알림
 	}
 }

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -190,18 +190,20 @@ public class MatchService {
 	}
 
 	@Transactional
-	public void accept(Long matchId, Users loginUser) {
-		// 0. 이미 완료된 매칭 세션인지 검증
-		MatchingSession session = matchingSessionRepository
-			.findByIdWithLock(matchId)
+	public void accept(Users loginUser) {
+		// 0. 현재 활성 매칭 멤버 조회
+		MatchingMember me = matchingMemberRepository
+			.findCurrentActiveByUserId(loginUser.getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
-		// 1. 매칭 세션 접근 권한 확인 및 멤버 조회
-		List<MatchingMember> members = validateMatchAccessAndGetMembers(session, loginUser.getId());
-		MatchingMember me = members.stream()
-			.filter(m -> m.getUser().getId().equals(loginUser.getId())) // 리스트 중 내 ID와 일치하는 객체 찾기
-			.findFirst()
-			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_DATA_ERROR));
+		// Session: PESSIMISTIC_LOCK
+		MatchingSession session = matchingSessionRepository
+			.findByIdWithLock(me.getMatchingSession().getId())
+			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
+
+		// 1. 세션 전체 멤버 조회
+		List<MatchingMember> members = matchingMemberRepository
+			.findAllActiveBySessionIdWithFetch(session.getId());
 
 		// 2. 호스트 여부 확인 - 호스트는 수락할 수 없음
 		validateNotHost(me);
@@ -213,32 +215,35 @@ public class MatchService {
 
 		// 4. 수락 처리
 		me.accept();
-		log.info("매칭 수락: matchId={}, userId={}", matchId, loginUser.getId());
+		Long sessionId = session.getId();
+		log.info("매칭 수락: sessionId={}, userId={}", sessionId, loginUser.getId());
 
 		// 5. 전원 수락 여부 확인
-		if (!matchingMemberRepository.isAllAccepted(matchId, MatchConstants.TEAM_SIZE)) {
-			eventPublisher.publishEvent(new MatchAcceptedEvent(matchId, loginUser.getId()));
+		if (!matchingMemberRepository.isAllAccepted(sessionId, MatchConstants.TEAM_SIZE)) {
+			eventPublisher.publishEvent(new MatchAcceptedEvent(sessionId, loginUser.getId()));
 			return;
 		}
 
 		// 6. 전원 수락 시 ProjectGroup 생성
-		log.info("전원 수락 완료, ProjectGroup 생성 시작: matchId={}", matchId);
+		log.info("전원 수락 완료, ProjectGroup 생성 시작: sessionId={}", sessionId);
 		completeMatching(session, members);
 	}
 
 	@Transactional
-	public void reject(Long matchId, Users loginUser) {
-		// 0. 이미 완료된 매칭 세션인지 검증
-		MatchingSession session = matchingSessionRepository
-			.findByIdWithLock(matchId)
+	public void reject(Users loginUser) {
+		// 0. 현재 활성 매칭 멤버 조회
+		MatchingMember me = matchingMemberRepository
+			.findCurrentActiveByUserId(loginUser.getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
-		// 1. 매칭 세션 접근 권한 확인 및 멤버 조회
-		List<MatchingMember> members = validateMatchAccessAndGetMembers(session, loginUser.getId());
-		MatchingMember me = members.stream()
-			.filter(m -> m.getUser().getId().equals(loginUser.getId())) // 리스트 중 내 ID와 일치하는 객체 찾기
-			.findFirst()
-			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED));
+		// Session: PESSIMISTIC_LOCK
+		MatchingSession session = matchingSessionRepository
+			.findByIdWithLock(me.getMatchingSession().getId())
+			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
+
+		// 1. 세션 전체 멤버 조회
+		List<MatchingMember> members = matchingMemberRepository
+			.findAllActiveBySessionIdWithFetch(session.getId());
 
 		// 2. 호스트 여부 조회: 호스트는 거절 불가
 		validateNotHost(me);
@@ -255,7 +260,8 @@ public class MatchService {
 
 		// 6. 해당 유저의 매칭 요청 상태 WAITING으로 초기화
 		me.getProjectRequest().resetToWaiting();
-		log.info("매칭 거절: matchId={}, userId={}", matchId, me.getUser().getId());
+		Long sessionId = session.getId();
+		log.info("매칭 거절: sessionId={}, userId={}", sessionId, me.getUser().getId());
 
 		// 7. 이벤트 발행
 		List<Long> remainingUserIds = members.stream()
@@ -263,7 +269,7 @@ public class MatchService {
 			.map(m -> m.getUser().getId())
 			.toList();
 
-		eventPublisher.publishEvent(new MatchRejectedEvent(matchId, loginUser.getId(), remainingUserIds));
+		eventPublisher.publishEvent(new MatchRejectedEvent(sessionId, loginUser.getId(), remainingUserIds));
 	}
 
 	@Transactional

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -190,19 +190,25 @@ public class MatchService {
 
 	@Transactional
 	public void accept(Users loginUser) {
-		// 0. 현재 활성 매칭 멤버 조회
-		MatchingMember me = matchingMemberRepository
+		// 0. 현재 활성 매칭 멤버 조회 (세션 ID 확보용)
+		MatchingMember preMe = matchingMemberRepository
 			.findCurrentActiveByUserId(loginUser.getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// Session: PESSIMISTIC_LOCK
 		MatchingSession session = matchingSessionRepository
-			.findByIdWithLock(me.getMatchingSession().getId())
+			.findByIdWithLock(preMe.getMatchingSession().getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// 1. 세션 전체 멤버 조회
 		List<MatchingMember> members = matchingMemberRepository
 			.findAllActiveBySessionIdWithFetch(session.getId());
+
+		// 락 대기 중 cancel이 커밋됐을 수 있으므로 me를 재조회
+		MatchingMember me = members.stream()
+			.filter(m -> m.getUser().getId().equals(loginUser.getId()))
+			.findFirst()
+			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// 2. 호스트 여부 확인 - 호스트는 수락할 수 없음
 		validateNotHost(me);
@@ -230,19 +236,25 @@ public class MatchService {
 
 	@Transactional
 	public void reject(Users loginUser) {
-		// 0. 현재 활성 매칭 멤버 조회
-		MatchingMember me = matchingMemberRepository
+		// 0. 현재 활성 매칭 멤버 조회 (세션 ID 확보용)
+		MatchingMember preMe = matchingMemberRepository
 			.findCurrentActiveByUserId(loginUser.getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// Session: PESSIMISTIC_LOCK
 		MatchingSession session = matchingSessionRepository
-			.findByIdWithLock(me.getMatchingSession().getId())
+			.findByIdWithLock(preMe.getMatchingSession().getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// 1. 세션 전체 멤버 조회
 		List<MatchingMember> members = matchingMemberRepository
 			.findAllActiveBySessionIdWithFetch(session.getId());
+
+		// 락 대기 중 cancel이 커밋됐을 수 있으므로 me를 재조회
+		MatchingMember me = members.stream()
+			.filter(m -> m.getUser().getId().equals(loginUser.getId()))
+			.findFirst()
+			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// 2. 호스트 여부 조회: 호스트는 거절 불가
 		validateNotHost(me);

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -102,8 +102,7 @@ public class MatchService {
 			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND));
 
 		if (candidate.getStatus() != Status.WAITING) {
-			log.debug("후보 상태 변경됨 - 빈자리 충원 스킵: sessionId={}, candidateUserId={}",
-				sessionId, candidate.getUser().getId());
+			log.debug("후보 상태 변경됨 - 빈자리 충원 스킵: sessionId={}", sessionId);
 			return;
 		}
 
@@ -176,7 +175,7 @@ public class MatchService {
 
 		MatchingMember hostMember = hosts.getFirst();
 		if (!Boolean.TRUE.equals(hostMember.getIsAccepted())) {
-			log.error("호스트 수락 상태 부정합: sessionId={}, userId={}", sessionId, hostMember.getUser().getId());
+			log.error("호스트 수락 상태 부정합: sessionId={}", sessionId);
 			throw new ApplicationException(ErrorCode.MATCH_DATA_ERROR);
 		}
 
@@ -216,7 +215,7 @@ public class MatchService {
 		// 4. 수락 처리
 		me.accept();
 		Long sessionId = session.getId();
-		log.info("매칭 수락: sessionId={}, userId={}", sessionId, loginUser.getId());
+		log.info("매칭 수락: sessionId={}", sessionId);
 
 		// 5. 전원 수락 여부 확인
 		if (!matchingMemberRepository.isAllAccepted(sessionId, MatchConstants.TEAM_SIZE)) {
@@ -261,7 +260,7 @@ public class MatchService {
 		// 6. 해당 유저의 매칭 요청 상태 WAITING으로 초기화
 		me.getProjectRequest().resetToWaiting();
 		Long sessionId = session.getId();
-		log.info("매칭 거절: sessionId={}, userId={}", sessionId, me.getUser().getId());
+		log.info("매칭 거절: sessionId={}", sessionId);
 
 		// 7. 이벤트 발행
 		List<Long> remainingUserIds = members.stream()
@@ -282,7 +281,7 @@ public class MatchService {
 		// 2. WAITING: 단순 취소
 		if (myPr.getStatus() == Status.WAITING) {
 			myPr.cancel();
-			log.info("매칭 요청 취소 - WAITING: prID={}, userId={}", myPr.getId(), loginUser.getId());
+			log.info("매칭 요청 취소 - WAITING: prId={}", myPr.getId());
 			return;
 		}
 
@@ -323,8 +322,7 @@ public class MatchService {
 			new MatchMemberCanceledEvent(sessionId, me.getUser().getId(), remainingUserIds)
 		);
 
-		log.info("멤버 매칭 취소 완료: prId={}, userId={}, sessionId={}",
-			me.getId(), me.getUser().getId(), sessionId);
+		log.info("멤버 매칭 취소 완료: prId={}, sessionId={}", me.getId(), sessionId);
 	}
 
 	private void cancelAsHost(MatchingMember me, List<MatchingMember> sessionMembers) {
@@ -353,8 +351,7 @@ public class MatchService {
 			new MatchSessionDisbandedEvent(sessionId, me.getUser().getId(), restoredUserIds)
 		);
 
-		log.info("호스트 매칭 취소 및 세션 해산: sessionId={}, hostUserId={}, restoredCount={}",
-			sessionId, me.getUser().getId(), restoredUserIds.size());
+		log.info("호스트 매칭 취소 및 세션 해산: sessionId={}, restoredCount={}", sessionId, restoredUserIds.size());
 	}
 
 	private List<MatchingMember> validateMatchAccessAndGetMembers(MatchingSession session, Long userId) {

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -124,14 +124,15 @@ public class MatchService {
 
 	// 매칭 세션 멤버 목록 조회
 	@Transactional(readOnly = true)
-	public MatchMemberResponse getMatchMembers(Long matchId, Users loginUser) {
-		// 0. 이미 완료된 매칭 세션인지 검증
-		MatchingSession session = matchingSessionRepository
-			.findByIdAndDeletedAtIsNull(matchId)
+	public MatchMemberResponse getMatchMembers(Users loginUser) {
+		// 0. 현재 활성 매칭 멤버 조회
+		MatchingMember me = matchingMemberRepository
+			.findCurrentActiveByUserId(loginUser.getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
-		// 1. 매칭 세션 접근 권한 확인 및 멤버 조회
-		List<MatchingMember> members = validateMatchAccessAndGetMembers(session, loginUser.getId());
+		// 1. 세션 전체 멤버 조회
+		List<MatchingMember> members = matchingMemberRepository
+			.findAllActiveBySessionIdWithFetch(me.getMatchingSession().getId());
 
 		// 2. MatchingMember dto
 		List<MatchMemberResponse.MemberDto> memberDtos = members.stream()
@@ -147,7 +148,7 @@ public class MatchService {
 			))
 			.toList();
 
-		return new MatchMemberResponse(matchId, memberDtos);
+		return new MatchMemberResponse(memberDtos);
 	}
 
 	// 매칭 세션 프로젝트 정보 조회

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -153,14 +153,16 @@ public class MatchService {
 
 	// 매칭 세션 프로젝트 정보 조회
 	@Transactional(readOnly = true)
-	public MatchProjectResponse getMatchProject(Long matchId, Users loginUser) {
-		// 0. 이미 완료된 매칭 세션인지 검증
-		MatchingSession session = matchingSessionRepository
-			.findByIdAndDeletedAtIsNull(matchId)
+	public MatchProjectResponse getMatchProject(Users loginUser) {
+		// 0. 현재 활성 매칭 멤버 조회
+		MatchingMember me = matchingMemberRepository
+			.findCurrentActiveByUserId(loginUser.getId())
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
-		// 1. 매칭 세션 접근 권한 확인 및 멤버 조회
-		List<MatchingMember> members = validateMatchAccessAndGetMembers(session, loginUser.getId());
+		// 1. 세션 전체 멤버 조회
+		Long sessionId = me.getMatchingSession().getId();
+		List<MatchingMember> members = matchingMemberRepository
+			.findAllActiveBySessionIdWithFetch(sessionId);
 
 		// 2. Host 검증 (단일 & 수락 상태)
 		List<MatchingMember> hosts = members.stream()
@@ -168,20 +170,19 @@ public class MatchService {
 			.toList();
 
 		if (hosts.size() != 1) {
-			log.error("매칭 호스트 데이터 부정합: matchId={}, hostCount={}", matchId, hosts.size());
+			log.error("매칭 호스트 데이터 부정합: sessionId={}, hostCount={}", sessionId, hosts.size());
 			throw new ApplicationException(ErrorCode.MATCH_DATA_ERROR);
 		}
 
 		MatchingMember hostMember = hosts.getFirst();
 		if (!Boolean.TRUE.equals(hostMember.getIsAccepted())) {
-			log.error("호스트 수락 상태 부정합: matchId={}, userId={}", matchId, hostMember.getUser().getId());
+			log.error("호스트 수락 상태 부정합: sessionId={}, userId={}", sessionId, hostMember.getUser().getId());
 			throw new ApplicationException(ErrorCode.MATCH_DATA_ERROR);
 		}
 
 		// 3. Host 프로젝트 정보 추출 및 응답
 		ProjectRequest hostPr = hostMember.getProjectRequest();
 		return new MatchProjectResponse(
-			matchId,
 			hostPr.getProjectTitle(),
 			hostPr.getProjectDescription(),
 			hostPr.getProjectMvp()

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -83,17 +83,9 @@ public class ProjectRequestService {
 			List.of(Status.WAITING, Status.MATCHING)
 		).orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND, "진행 중인 매칭 요청이 없습니다."));
 
-		Long matchId = null;
-		// MATCHING: matchId 반환
-		if (projectRequest.getStatus() == Status.MATCHING) {
-			matchId = matchingMemberRepository
-				.findCurrentActiveByUserId(user.getId())
-				.map(m -> m.getMatchingSession().getId())
-				.orElseThrow(() -> {
-					log.error("활성 매칭 멤버 데이터 부정합: userId={}", user.getId());
-					return new ApplicationException(ErrorCode.MATCH_DATA_ERROR);
-				});
-		}
-		return new ProjectRequestStatusResponse(projectRequest.getStatus(), matchId);
+		return new ProjectRequestStatusResponse(
+			projectRequest.getStatus(),
+			projectRequest.getRole()
+		);
 	}
 }

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -83,6 +83,17 @@ public class ProjectRequestService {
 			List.of(Status.WAITING, Status.MATCHING)
 		).orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND, "진행 중인 매칭 요청이 없습니다."));
 
+		// MATCHING 상태인데 활성 MatchingMember가 없으면 데이터 불일치
+		if (projectRequest.getStatus() == Status.MATCHING) {
+			boolean hasActiveMember = matchingMemberRepository
+				.findCurrentActiveByUserId(user.getId())
+				.isPresent();
+			if (!hasActiveMember) {
+				log.error("MATCHING 상태지만 활성 매칭 멤버 없음: userId={}", user.getId());
+				throw new ApplicationException(ErrorCode.MATCH_DATA_ERROR);
+			}
+		}
+
 		return new ProjectRequestStatusResponse(
 			projectRequest.getStatus(),
 			projectRequest.getRole()

--- a/src/main/java/team/po/feature/match/service/ProjectRequestService.java
+++ b/src/main/java/team/po/feature/match/service/ProjectRequestService.java
@@ -60,8 +60,8 @@ public class ProjectRequestService {
 				.projectMvp(request.projectMvp())
 				.build();
 			projectRequestRepository.save(projectRequest);
-			log.info("매칭 요청 생성 완료. userId: {}, projectRequestId: {}, role: {}",
-				user.getId(), projectRequest.getId(), projectRequest.getRole());
+			log.info("매칭 요청 생성 완료. projectRequestId: {}, role: {}",
+				projectRequest.getId(), projectRequest.getRole());
 		} catch (DataIntegrityViolationException e) { // 동시 요청 Race Condition
 			throw new ApplicationException(ErrorCode.PROJECT_REQUEST_ALREADY_EXISTS);
 		}

--- a/src/test/java/team/po/feature/match/controller/MatchControllerTest.java
+++ b/src/test/java/team/po/feature/match/controller/MatchControllerTest.java
@@ -79,39 +79,26 @@ class MatchControllerTest {
 	@Test
 	void getMatchMembers_returnsOk() throws Exception {
 		MatchMemberResponse response = new MatchMemberResponse(
-			42L,
 			List.of(new MatchMemberResponse.MemberDto(
 				1L, "tester", Role.BACKEND, 1, 50, null, true, true
 			))
 		);
-		when(matchService.getMatchMembers(eq(42L), any(Users.class))).thenReturn(response);
+		when(matchService.getMatchMembers(any(Users.class))).thenReturn(response);
 
-		mockMvc.perform(get("/api/match/42/members"))
+		mockMvc.perform(get("/api/match/members"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.matchId").value(42))
 			.andExpect(jsonPath("$.members[0].nickname").value("tester"));
 	}
 
 	@Test
 	void getMatchMembers_returnsNotFound_whenSessionNotExists() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_NOT_FOUND))
-			.when(matchService).getMatchMembers(eq(42L), any(Users.class));
+			.when(matchService).getMatchMembers(any(Users.class));
 
-		mockMvc.perform(get("/api/match/42/members"))
+		mockMvc.perform(get("/api/match/members"))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.code").value("MATCH_NOT_FOUND"))
 			.andExpect(jsonPath("$.message").value("이미 완료되었거나 존재하지 않는 매칭 세션입니다."));
-	}
-
-	@Test
-	void getMatchMembers_returnsForbidden_whenNotMember() throws Exception {
-		doThrow(new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED))
-			.when(matchService).getMatchMembers(eq(42L), any(Users.class));
-
-		// MATCH_ACCESS_DENIED는 BAD_REQUEST로 정의됨
-		mockMvc.perform(get("/api/match/42/members"))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value("MATCH_ACCESS_DENIED"));
 	}
 
 	// ===== getMatchProject =====

--- a/src/test/java/team/po/feature/match/controller/MatchControllerTest.java
+++ b/src/test/java/team/po/feature/match/controller/MatchControllerTest.java
@@ -105,42 +105,31 @@ class MatchControllerTest {
 
 	@Test
 	void getMatchProject_returnsOk() throws Exception {
-		MatchProjectResponse response = new MatchProjectResponse(42L, "팀포", "설명", "MVP");
-		when(matchService.getMatchProject(eq(42L), any(Users.class))).thenReturn(response);
+		MatchProjectResponse response = new MatchProjectResponse("팀포", "설명", "MVP");
+		when(matchService.getMatchProject(any(Users.class))).thenReturn(response);
 
-		mockMvc.perform(get("/api/match/42/project"))
+		mockMvc.perform(get("/api/match/project"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.matchId").value(42))
 			.andExpect(jsonPath("$.projectTitle").value("팀포"));
 	}
 
 	@Test
 	void getMatchProject_returnsNotFound_whenSessionNotExists() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_NOT_FOUND))
-			.when(matchService).getMatchProject(eq(42L), any(Users.class));
+			.when(matchService).getMatchProject(any(Users.class));
 
-		mockMvc.perform(get("/api/match/42/project"))
+		mockMvc.perform(get("/api/match/project"))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.code").value("MATCH_NOT_FOUND"))
 			.andExpect(jsonPath("$.message").value("이미 완료되었거나 존재하지 않는 매칭 세션입니다."));
 	}
 
 	@Test
-	void getMatchProject_returnsBadRequest_whenNotMember() throws Exception {
-		doThrow(new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED))
-			.when(matchService).getMatchProject(eq(42L), any(Users.class));
-
-		mockMvc.perform(get("/api/match/42/project"))
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value("MATCH_ACCESS_DENIED"));
-	}
-
-	@Test
 	void getMatchProject_returnsInternalServerError_whenDataIntegrity() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_DATA_ERROR))
-			.when(matchService).getMatchProject(eq(42L), any(Users.class));
+			.when(matchService).getMatchProject(any(Users.class));
 
-		mockMvc.perform(get("/api/match/42/project"))
+		mockMvc.perform(get("/api/match/project"))
 			.andExpect(status().isInternalServerError())
 			.andExpect(jsonPath("$.code").value("MATCH_DATA_ERROR"));
 	}

--- a/src/test/java/team/po/feature/match/controller/MatchControllerTest.java
+++ b/src/test/java/team/po/feature/match/controller/MatchControllerTest.java
@@ -138,18 +138,18 @@ class MatchControllerTest {
 
 	@Test
 	void accept_returnsOk() throws Exception {
-		doNothing().when(matchService).accept(eq(42L), any(Users.class));
+		doNothing().when(matchService).accept(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/accept"))
+		mockMvc.perform(post("/api/match/accept"))
 			.andExpect(status().isOk());
 	}
 
 	@Test
 	void accept_returnsNotFound_whenSessionNotExists() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_NOT_FOUND))
-			.when(matchService).accept(eq(42L), any(Users.class));
+			.when(matchService).accept(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/accept"))
+		mockMvc.perform(post("/api/match/accept"))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.code").value("MATCH_NOT_FOUND"));
 	}
@@ -157,9 +157,9 @@ class MatchControllerTest {
 	@Test
 	void accept_returnsBadRequest_whenHost() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED))
-			.when(matchService).accept(eq(42L), any(Users.class));
+			.when(matchService).accept(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/accept"))
+		mockMvc.perform(post("/api/match/accept"))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("MATCH_ACCESS_DENIED"));
 	}
@@ -168,18 +168,18 @@ class MatchControllerTest {
 
 	@Test
 	void reject_returnsOk() throws Exception {
-		doNothing().when(matchService).reject(eq(42L), any(Users.class));
+		doNothing().when(matchService).reject(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/reject"))
+		mockMvc.perform(post("/api/match/reject"))
 			.andExpect(status().isOk());
 	}
 
 	@Test
 	void reject_returnsNotFound_whenSessionNotExists() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_NOT_FOUND))
-			.when(matchService).reject(eq(42L), any(Users.class));
+			.when(matchService).reject(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/reject"))
+		mockMvc.perform(post("/api/match/reject"))
 			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.code").value("MATCH_NOT_FOUND"));
 	}
@@ -187,9 +187,9 @@ class MatchControllerTest {
 	@Test
 	void reject_returnsBadRequest_whenHost() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED))
-			.when(matchService).reject(eq(42L), any(Users.class));
+			.when(matchService).reject(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/reject"))
+		mockMvc.perform(post("/api/match/reject"))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("MATCH_ACCESS_DENIED"));
 	}
@@ -197,9 +197,9 @@ class MatchControllerTest {
 	@Test
 	void reject_returnsBadRequest_whenAlreadyAccepted() throws Exception {
 		doThrow(new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED))
-			.when(matchService).reject(eq(42L), any(Users.class));
+			.when(matchService).reject(any(Users.class));
 
-		mockMvc.perform(post("/api/match/42/reject"))
+		mockMvc.perform(post("/api/match/reject"))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("MATCH_ACCESS_DENIED"));
 	}

--- a/src/test/java/team/po/feature/match/controller/ProjectRequestControllerTest.java
+++ b/src/test/java/team/po/feature/match/controller/ProjectRequestControllerTest.java
@@ -28,6 +28,7 @@ import team.po.exception.ApplicationException;
 import team.po.exception.CustomExceptionHandler;
 import team.po.exception.ErrorCode;
 import team.po.feature.match.dto.ProjectRequestStatusResponse;
+import team.po.feature.match.enums.Role;
 import team.po.feature.match.enums.Status;
 import team.po.feature.match.service.ProjectRequestService;
 import team.po.feature.user.domain.Users;
@@ -122,11 +123,12 @@ class ProjectRequestControllerTest {
 	@Test
 	void getProjectRequestStatus_returnsOk() throws Exception {
 		when(projectRequestService.getProjectRequestStatus(any(Users.class)))
-			.thenReturn(new ProjectRequestStatusResponse(Status.WAITING, null));
+			.thenReturn(new ProjectRequestStatusResponse(Status.WAITING, Role.BACKEND));
 
 		mockMvc.perform(get("/api/match/status"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.status").value("WAITING"));
+			.andExpect(jsonPath("$.status").value("WAITING"))
+			.andExpect(jsonPath("$.role").value("BACKEND"));
 	}
 
 	@Test

--- a/src/test/java/team/po/feature/match/service/MatchServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/MatchServiceTest.java
@@ -195,12 +195,13 @@ class MatchServiceTest {
 		MatchingMember hostMember = createHostMember(session, hostPr);
 		MatchingMember myMember = createMemberMember(session, myPr);
 
+		when(matchingMemberRepository.findCurrentActiveByUserId(2L)).thenReturn(Optional.of(myMember));
 		when(matchingSessionRepository.findByIdWithLock(42L)).thenReturn(Optional.of(session));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L))
 			.thenReturn(List.of(hostMember, myMember));
 		when(matchingMemberRepository.isAllAccepted(42L, MatchConstants.TEAM_SIZE)).thenReturn(false);
 
-		matchService.accept(42L, loginUser);
+		matchService.accept(loginUser);
 
 		assertThat(myMember.getIsAccepted()).isTrue();
 		verify(matchingMemberRepository).isAllAccepted(42L, MatchConstants.TEAM_SIZE);
@@ -222,11 +223,12 @@ class MatchServiceTest {
 		MatchingMember myMember = createMemberMember(session, myPr);
 		myMember.accept();
 
+		when(matchingMemberRepository.findCurrentActiveByUserId(2L)).thenReturn(Optional.of(myMember));
 		when(matchingSessionRepository.findByIdWithLock(42L)).thenReturn(Optional.of(session));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L))
 			.thenReturn(List.of(hostMember, myMember));
 
-		matchService.accept(42L, loginUser);
+		matchService.accept(loginUser);
 
 		verify(matchingMemberRepository, never()).isAllAccepted(any(), anyInt());
 	}
@@ -238,10 +240,10 @@ class MatchServiceTest {
 		ProjectRequest hostPr = createHostRequest(loginUser);
 		MatchingMember hostMember = createHostMember(session, hostPr);
 
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.of(hostMember));
 		when(matchingSessionRepository.findByIdWithLock(42L)).thenReturn(Optional.of(session));
-		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
 
-		assertThatThrownBy(() -> matchService.accept(42L, loginUser))
+		assertThatThrownBy(() -> matchService.accept(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 
@@ -262,11 +264,12 @@ class MatchServiceTest {
 		MatchingMember hostMember = createHostMember(session, hostPr);
 		MatchingMember myMember = createMemberMember(session, myPr);
 
+		when(matchingMemberRepository.findCurrentActiveByUserId(2L)).thenReturn(Optional.of(myMember));
 		when(matchingSessionRepository.findByIdWithLock(42L)).thenReturn(Optional.of(session));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L))
 			.thenReturn(List.of(hostMember, myMember));
 
-		matchService.reject(42L, loginUser);
+		matchService.reject(loginUser);
 
 		assertThat(myMember.getIsAccepted()).isFalse();
 		assertThat(myMember.isDeleted()).isTrue();
@@ -281,10 +284,10 @@ class MatchServiceTest {
 		ProjectRequest hostPr = createHostRequest(loginUser);
 		MatchingMember hostMember = createHostMember(session, hostPr);
 
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.of(hostMember));
 		when(matchingSessionRepository.findByIdWithLock(42L)).thenReturn(Optional.of(session));
-		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
 
-		assertThatThrownBy(() -> matchService.reject(42L, loginUser))
+		assertThatThrownBy(() -> matchService.reject(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 
@@ -303,11 +306,12 @@ class MatchServiceTest {
 		MatchingMember myMember = createMemberMember(session, myPr);
 		myMember.accept();
 
+		when(matchingMemberRepository.findCurrentActiveByUserId(2L)).thenReturn(Optional.of(myMember));
 		when(matchingSessionRepository.findByIdWithLock(42L)).thenReturn(Optional.of(session));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L))
 			.thenReturn(List.of(hostMember, myMember));
 
-		assertThatThrownBy(() -> matchService.reject(42L, loginUser))
+		assertThatThrownBy(() -> matchService.reject(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 

--- a/src/test/java/team/po/feature/match/service/MatchServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/MatchServiceTest.java
@@ -104,38 +104,22 @@ class MatchServiceTest {
 		ReflectionTestUtils.setField(hostPr, "id", 1L);
 		MatchingMember hostMember = createHostMember(session, hostPr);
 
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(session));
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.of(hostMember));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
 
-		MatchMemberResponse response = matchService.getMatchMembers(42L, loginUser);
+		MatchMemberResponse response = matchService.getMatchMembers(loginUser);
 
-		assertThat(response.matchId()).isEqualTo(42L);
 		assertThat(response.members()).hasSize(1);
 		assertThat(response.members().get(0).nickname()).isEqualTo("tester1");
 		assertThat(response.members().get(0).isHost()).isTrue();
 	}
 
 	@Test
-	void getMatchMembers_throwsNotFound_whenSessionNotExists() {
+	void getMatchMembers_throwsNotFound_whenNoActiveSession() {
 		Users loginUser = createUser(1L);
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.empty());
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> matchService.getMatchMembers(42L, loginUser))
-			.isInstanceOf(ApplicationException.class);
-	}
-
-	@Test
-	void getMatchMembers_throwsForbidden_whenNotMember() {
-		Users loginUser = createUser(2L);
-		Users otherUser = createUser(1L);
-		MatchingSession session = createSession(42L);
-		ProjectRequest hostPr = createHostRequest(otherUser);
-		MatchingMember hostMember = createHostMember(session, hostPr);
-
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(session));
-		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
-
-		assertThatThrownBy(() -> matchService.getMatchMembers(42L, loginUser))
+		assertThatThrownBy(() -> matchService.getMatchMembers(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 

--- a/src/test/java/team/po/feature/match/service/MatchServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/MatchServiceTest.java
@@ -133,36 +133,20 @@ class MatchServiceTest {
 		ReflectionTestUtils.setField(hostPr, "id", 1L);
 		MatchingMember hostMember = createHostMember(session, hostPr);
 
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(session));
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.of(hostMember));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
 
-		MatchProjectResponse response = matchService.getMatchProject(42L, loginUser);
+		MatchProjectResponse response = matchService.getMatchProject(loginUser);
 
-		assertThat(response.matchId()).isEqualTo(42L);
 		assertThat(response.projectTitle()).isEqualTo("팀포");
 	}
 
 	@Test
-	void getMatchProject_throwsNotFound_whenSessionNotExists() {
+	void getMatchProject_throwsNotFound_whenNoActiveSession() {
 		Users loginUser = createUser(1L);
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.empty());
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> matchService.getMatchProject(42L, loginUser))
-			.isInstanceOf(ApplicationException.class);
-	}
-
-	@Test
-	void getMatchProject_throwsForbidden_whenNotMember() {
-		Users loginUser = createUser(2L);
-		Users otherUser = createUser(1L);
-		MatchingSession session = createSession(42L);
-		ProjectRequest hostPr = createHostRequest(otherUser);
-		MatchingMember hostMember = createHostMember(session, hostPr);
-
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(session));
-		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
-
-		assertThatThrownBy(() -> matchService.getMatchProject(42L, loginUser))
+		assertThatThrownBy(() -> matchService.getMatchProject(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 
@@ -173,10 +157,10 @@ class MatchServiceTest {
 		ProjectRequest memberPr = createMemberRequest(loginUser);
 		MatchingMember memberMember = createMemberMember(session, memberPr);
 
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(session));
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.of(memberMember));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(memberMember));
 
-		assertThatThrownBy(() -> matchService.getMatchProject(42L, loginUser))
+		assertThatThrownBy(() -> matchService.getMatchProject(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 
@@ -188,10 +172,10 @@ class MatchServiceTest {
 		MatchingMember hostMember = createHostMember(session, hostPr);
 		ReflectionTestUtils.setField(hostMember, "isAccepted", null);
 
-		when(matchingSessionRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(session));
+		when(matchingMemberRepository.findCurrentActiveByUserId(1L)).thenReturn(Optional.of(hostMember));
 		when(matchingMemberRepository.findAllActiveBySessionIdWithFetch(42L)).thenReturn(List.of(hostMember));
 
-		assertThatThrownBy(() -> matchService.getMatchProject(42L, loginUser))
+		assertThatThrownBy(() -> matchService.getMatchProject(loginUser))
 			.isInstanceOf(ApplicationException.class);
 	}
 


### PR DESCRIPTION
## 📌 Related Issue

Closes #76

## 🚀 Description

- 매칭 상태 조회 API 응답에 `role` 필드 추가 / `matchId` 제거
- 매칭 관련 API에서 `matchId` 제거
- Swagger 문서에서 인증 사용자 파라미터 숨김 처리 (`@Parameter(hidden = true)`)
- 매칭 API 변경에 맞춰 불필요한 로그 정보 정리

## 📢 Review Point
- `matchId` 제거에 따라 기존 API 동작에 영향이 없는지 확인 부탁합니다.

## 📚 Etc (선택)
- 테스트를 통해 매칭 시스템이 기존과 동일하게 동작하는 거 확인했습니다.
- 별 거 없어영