### PR TITLE
Feat : 팀스페이스 기여도 가시화 API 

### DIFF
--- a/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
+++ b/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
@@ -97,4 +97,16 @@ public class TeamspaceController {
 
 		return ResponseEntity.ok(response);
 	}
+
+	@Operation(summary = "Repository Pull Request 기여도 수동 동기화 API")
+	@PostMapping("/{projectGroupId}/github/repositories/{githubRepositoryId}/pull-request-contributions/sync")
+	public ResponseEntity<Void> syncGithubPullRequestContributions(
+		@Parameter(hidden = true) @LoginUser Users user,
+		@PathVariable Long projectGroupId,
+		@PathVariable Long githubRepositoryId
+	) {
+		teamspaceService.syncGithubPullRequestContributions(user, projectGroupId, githubRepositoryId);
+
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
+++ b/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
@@ -115,7 +115,7 @@ public class TeamspaceController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "Repository Pull Request 기여도 동기화 API")
+	@Operation(summary = "Repository Pull Request 기여도	동기화 API")
 	@PostMapping("/{projectGroupId}/github/repositories/{githubRepositoryId}/pull-request-contributions/sync")
 	public ResponseEntity<Void> syncGithubPullRequestContributions(
 		@Parameter(hidden = true) @LoginUser Users user,

--- a/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
+++ b/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
@@ -115,7 +115,7 @@ public class TeamspaceController {
 		return ResponseEntity.ok(response);
 	}
 
-	@Operation(summary = "Repository Pull Request 기여도 수동 동기화 API")
+	@Operation(summary = "Repository Pull Request 기여도 동기화 API")
 	@PostMapping("/{projectGroupId}/github/repositories/{githubRepositoryId}/pull-request-contributions/sync")
 	public ResponseEntity<Void> syncGithubPullRequestContributions(
 		@Parameter(hidden = true) @LoginUser Users user,

--- a/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
+++ b/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
@@ -18,6 +18,7 @@ import team.po.feature.teamspace.dto.CompleteGithubAppInstallationRequest;
 import team.po.feature.teamspace.dto.CreateGithubAppInstallationUrlResponse;
 import team.po.feature.teamspace.dto.GetAvailableGithubRepositoryList;
 import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
+import team.po.feature.teamspace.dto.GetGithubRepositoryContributionResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.service.TeamspaceService;
@@ -94,6 +95,22 @@ public class TeamspaceController {
 		@PathVariable Long projectGroupId
 	) {
 		GetGithubRepositoryListResponse response = teamspaceService.getGithubRepositoryList(user, projectGroupId);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "Repository 기여도 조회 API")
+	@GetMapping("/{projectGroupId}/github/repositories/{githubRepositoryId}/contributions")
+	public ResponseEntity<GetGithubRepositoryContributionResponse> getGithubRepositoryContributions(
+		@Parameter(hidden = true) @LoginUser Users user,
+		@PathVariable Long projectGroupId,
+		@PathVariable Long githubRepositoryId
+	) {
+		GetGithubRepositoryContributionResponse response = teamspaceService.getGithubRepositoryContributions(
+			user,
+			projectGroupId,
+			githubRepositoryId
+		);
 
 		return ResponseEntity.ok(response);
 	}

--- a/src/main/java/team/po/feature/teamspace/domain/GithubPullRequestContribution.java
+++ b/src/main/java/team/po/feature/teamspace/domain/GithubPullRequestContribution.java
@@ -118,31 +118,4 @@ public class GithubPullRequestContribution {
 		this.syncedAt = syncedAt;
 	}
 
-	public void updatePullRequestContribution(
-		String title,
-		Long authorGithubUserId,
-		String authorGithubUsername,
-		String state,
-		boolean merged,
-		Instant mergedAt,
-		int additions,
-		int deletions,
-		int changedFiles,
-		int linkedIssueCount,
-		String htmlUrl,
-		Instant syncedAt
-	) {
-		this.title = title;
-		this.authorGithubUserId = authorGithubUserId;
-		this.authorGithubUsername = authorGithubUsername;
-		this.state = state;
-		this.merged = merged;
-		this.mergedAt = mergedAt;
-		this.additions = additions;
-		this.deletions = deletions;
-		this.changedFiles = changedFiles;
-		this.linkedIssueCount = linkedIssueCount;
-		this.htmlUrl = htmlUrl;
-		this.syncedAt = syncedAt;
-	}
 }

--- a/src/main/java/team/po/feature/teamspace/domain/GithubPullRequestContribution.java
+++ b/src/main/java/team/po/feature/teamspace/domain/GithubPullRequestContribution.java
@@ -1,0 +1,148 @@
+package team.po.feature.teamspace.domain;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.po.feature.projectgroup.domain.ProjectGroup;
+
+@Entity
+@Table(name = "github_pull_request_contribution")
+@NoArgsConstructor
+@Getter
+public class GithubPullRequestContribution {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "project_group_id", nullable = false)
+	private ProjectGroup projectGroup;
+
+	@Column(name = "github_repository_id", nullable = false)
+	private Long githubRepositoryId;
+
+	@Column(name = "github_pr_id", nullable = false)
+	private Long githubPrId;
+
+	@Column(name = "pr_number", nullable = false)
+	private Long prNumber;
+
+	@Column(name = "title", nullable = false, length = 512)
+	private String title;
+
+	@Column(name = "author_github_user_id", nullable = false)
+	private Long authorGithubUserId;
+
+	@Column(name = "author_github_username", nullable = false)
+	private String authorGithubUsername;
+
+	@Column(name = "state", nullable = false)
+	private String state;
+
+	@Column(name = "merged", nullable = false)
+	private boolean merged;
+
+	@Column(name = "merged_at")
+	private Instant mergedAt;
+
+	@Column(name = "additions", nullable = false)
+	private int additions;
+
+	@Column(name = "deletions", nullable = false)
+	private int deletions;
+
+	@Column(name = "changed_files", nullable = false)
+	private int changedFiles;
+
+	@Column(name = "linked_issue_count", nullable = false)
+	private int linkedIssueCount;
+
+	@Column(name = "html_url", nullable = false, length = 2048)
+	private String htmlUrl;
+
+	@Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+	private Instant createdAt;
+
+	@Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+	private Instant updatedAt;
+
+	@Column(name = "synced_at", nullable = false)
+	private Instant syncedAt;
+
+	@Builder
+	public GithubPullRequestContribution(
+		ProjectGroup projectGroup,
+		Long githubRepositoryId,
+		Long githubPrId,
+		Long prNumber,
+		String title,
+		Long authorGithubUserId,
+		String authorGithubUsername,
+		String state,
+		boolean merged,
+		Instant mergedAt,
+		int additions,
+		int deletions,
+		int changedFiles,
+		int linkedIssueCount,
+		String htmlUrl,
+		Instant syncedAt
+	) {
+		this.projectGroup = projectGroup;
+		this.githubRepositoryId = githubRepositoryId;
+		this.githubPrId = githubPrId;
+		this.prNumber = prNumber;
+		this.title = title;
+		this.authorGithubUserId = authorGithubUserId;
+		this.authorGithubUsername = authorGithubUsername;
+		this.state = state;
+		this.merged = merged;
+		this.mergedAt = mergedAt;
+		this.additions = additions;
+		this.deletions = deletions;
+		this.changedFiles = changedFiles;
+		this.linkedIssueCount = linkedIssueCount;
+		this.htmlUrl = htmlUrl;
+		this.syncedAt = syncedAt;
+	}
+
+	public void updatePullRequestContribution(
+		String title,
+		Long authorGithubUserId,
+		String authorGithubUsername,
+		String state,
+		boolean merged,
+		Instant mergedAt,
+		int additions,
+		int deletions,
+		int changedFiles,
+		int linkedIssueCount,
+		String htmlUrl,
+		Instant syncedAt
+	) {
+		this.title = title;
+		this.authorGithubUserId = authorGithubUserId;
+		this.authorGithubUsername = authorGithubUsername;
+		this.state = state;
+		this.merged = merged;
+		this.mergedAt = mergedAt;
+		this.additions = additions;
+		this.deletions = deletions;
+		this.changedFiles = changedFiles;
+		this.linkedIssueCount = linkedIssueCount;
+		this.htmlUrl = htmlUrl;
+		this.syncedAt = syncedAt;
+	}
+}

--- a/src/main/java/team/po/feature/teamspace/dto/GetGithubRepositoryContributionResponse.java
+++ b/src/main/java/team/po/feature/teamspace/dto/GetGithubRepositoryContributionResponse.java
@@ -1,0 +1,22 @@
+package team.po.feature.teamspace.dto;
+
+import java.util.List;
+
+public record GetGithubRepositoryContributionResponse(
+	Long githubRepositoryId,
+	String repoName,
+	String fullName,
+	List<ContributorResponse> contributors
+) {
+	public record ContributorResponse(
+		Long githubUserId,
+		String githubUsername,
+		long mergedPrCount,
+		long linkedIssueCount,
+		long additions,
+		long deletions,
+		long changedFiles,
+		long contributionScore
+	) {
+	}
+}

--- a/src/main/java/team/po/feature/teamspace/dto/GetGithubRepositoryContributionResponse.java
+++ b/src/main/java/team/po/feature/teamspace/dto/GetGithubRepositoryContributionResponse.java
@@ -9,6 +9,7 @@ public record GetGithubRepositoryContributionResponse(
 	List<ContributorResponse> contributors
 ) {
 	public record ContributorResponse(
+		Long userId,
 		Long githubUserId,
 		String githubUsername,
 		long mergedPrCount,

--- a/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestInfo.java
+++ b/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestInfo.java
@@ -1,0 +1,18 @@
+package team.po.feature.teamspace.dto;
+
+import java.time.Instant;
+
+public record GithubPullRequestInfo(
+	Long githubPullRequestId,
+	Long pullNumber,
+	String title,
+	Long authorGithubUserId,
+	String authorGithubUsername,
+	String state,
+	Instant mergedAt,
+	Integer additions,
+	Integer deletions,
+	Integer changedFiles,
+	String htmlUrl
+) {
+}

--- a/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestInfo.java
+++ b/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestInfo.java
@@ -13,6 +13,7 @@ public record GithubPullRequestInfo(
 	Integer additions,
 	Integer deletions,
 	Integer changedFiles,
+	Integer linkedIssueCount,
 	String htmlUrl
 ) {
 }

--- a/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestSummary.java
+++ b/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestSummary.java
@@ -1,0 +1,15 @@
+package team.po.feature.teamspace.dto;
+
+import java.time.Instant;
+
+public record GithubPullRequestSummary(
+	Long githubPullRequestId,
+	Long pullNumber,
+	String title,
+	Long authorGithubUserId,
+	String authorGithubUsername,
+	String state,
+	Instant mergedAt,
+	String htmlUrl
+) {
+}

--- a/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestSyncContext.java
+++ b/src/main/java/team/po/feature/teamspace/dto/GithubPullRequestSyncContext.java
@@ -1,0 +1,8 @@
+package team.po.feature.teamspace.dto;
+
+public record GithubPullRequestSyncContext(
+	Long installationId,
+	String owner,
+	String repoName
+) {
+}

--- a/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
@@ -1,0 +1,8 @@
+package team.po.feature.teamspace.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team.po.feature.teamspace.domain.GithubPullRequestContribution;
+
+public interface GithubPullRequestContributionRepository extends JpaRepository<GithubPullRequestContribution, Long> {
+}

--- a/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
@@ -2,6 +2,7 @@ package team.po.feature.teamspace.repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,6 +18,19 @@ public interface GithubPullRequestContributionRepository extends JpaRepository<G
 		Long projectGroupId,
 		Long githubRepositoryId,
 		Long githubPrId
+	);
+
+	@Query("""
+		SELECT contribution.githubPrId
+		FROM GithubPullRequestContribution contribution
+		WHERE contribution.projectGroup.id = :projectGroupId
+			AND contribution.githubRepositoryId = :githubRepositoryId
+			AND contribution.githubPrId IN :githubPrIds
+		""")
+	Set<Long> findExistingGithubPrIds(
+		@Param("projectGroupId") Long projectGroupId,
+		@Param("githubRepositoryId") Long githubRepositoryId,
+		@Param("githubPrIds") Set<Long> githubPrIds
 	);
 
 	@Query("""

--- a/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
@@ -1,8 +1,16 @@
 package team.po.feature.teamspace.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import team.po.feature.teamspace.domain.GithubPullRequestContribution;
 
 public interface GithubPullRequestContributionRepository extends JpaRepository<GithubPullRequestContribution, Long> {
+	Optional<GithubPullRequestContribution>
+	findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(
+		Long projectGroupId,
+		Long githubRepositoryId,
+		Long githubPrId
+	);
 }

--- a/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import team.po.feature.projectgroup.domain.ProjectGroupMember;
 import team.po.feature.teamspace.domain.GithubPullRequestContribution;
+import team.po.feature.user.domain.GithubAccount;
 
 public interface GithubPullRequestContributionRepository extends JpaRepository<GithubPullRequestContribution, Long> {
 	Optional<GithubPullRequestContribution>
@@ -19,18 +21,25 @@ public interface GithubPullRequestContributionRepository extends JpaRepository<G
 
 	@Query("""
 		SELECT
-			contribution.authorGithubUserId AS githubUserId,
-			MAX(contribution.authorGithubUsername) AS githubUsername,
+			githubAccount.user.id AS userId,
+			githubAccount.githubUserId AS githubUserId,
+			MAX(githubAccount.githubUsername) AS githubUsername,
 			COUNT(contribution.id) AS mergedPrCount,
 			COALESCE(SUM(contribution.linkedIssueCount), 0) AS linkedIssueCount,
 			COALESCE(SUM(contribution.additions), 0) AS additions,
 			COALESCE(SUM(contribution.deletions), 0) AS deletions,
 			COALESCE(SUM(contribution.changedFiles), 0) AS changedFiles
 		FROM GithubPullRequestContribution contribution
+		JOIN GithubAccount githubAccount
+			ON githubAccount.githubUserId = contribution.authorGithubUserId
+			AND githubAccount.deletedAt IS NULL
+		JOIN ProjectGroupMember projectGroupMember
+			ON projectGroupMember.user.id = githubAccount.user.id
+			AND projectGroupMember.projectGroup.id = contribution.projectGroup.id
 		WHERE contribution.projectGroup.id = :projectGroupId
 			AND contribution.githubRepositoryId = :githubRepositoryId
 			AND contribution.merged = true
-		GROUP BY contribution.authorGithubUserId
+		GROUP BY githubAccount.user.id, githubAccount.githubUserId
 		ORDER BY COUNT(contribution.id) DESC, COALESCE(SUM(contribution.linkedIssueCount), 0) DESC
 		""")
 	List<GithubRepositoryContributionSummary> findContributionSummaries(
@@ -39,6 +48,8 @@ public interface GithubPullRequestContributionRepository extends JpaRepository<G
 	);
 
 	interface GithubRepositoryContributionSummary {
+		Long getUserId();
+
 		Long getGithubUserId();
 
 		String getGithubUsername();

--- a/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepository.java
@@ -1,8 +1,11 @@
 package team.po.feature.teamspace.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import team.po.feature.teamspace.domain.GithubPullRequestContribution;
 
@@ -13,4 +16,41 @@ public interface GithubPullRequestContributionRepository extends JpaRepository<G
 		Long githubRepositoryId,
 		Long githubPrId
 	);
+
+	@Query("""
+		SELECT
+			contribution.authorGithubUserId AS githubUserId,
+			MAX(contribution.authorGithubUsername) AS githubUsername,
+			COUNT(contribution.id) AS mergedPrCount,
+			COALESCE(SUM(contribution.linkedIssueCount), 0) AS linkedIssueCount,
+			COALESCE(SUM(contribution.additions), 0) AS additions,
+			COALESCE(SUM(contribution.deletions), 0) AS deletions,
+			COALESCE(SUM(contribution.changedFiles), 0) AS changedFiles
+		FROM GithubPullRequestContribution contribution
+		WHERE contribution.projectGroup.id = :projectGroupId
+			AND contribution.githubRepositoryId = :githubRepositoryId
+			AND contribution.merged = true
+		GROUP BY contribution.authorGithubUserId
+		ORDER BY COUNT(contribution.id) DESC, COALESCE(SUM(contribution.linkedIssueCount), 0) DESC
+		""")
+	List<GithubRepositoryContributionSummary> findContributionSummaries(
+		@Param("projectGroupId") Long projectGroupId,
+		@Param("githubRepositoryId") Long githubRepositoryId
+	);
+
+	interface GithubRepositoryContributionSummary {
+		Long getGithubUserId();
+
+		String getGithubUsername();
+
+		long getMergedPrCount();
+
+		long getLinkedIssueCount();
+
+		long getAdditions();
+
+		long getDeletions();
+
+		long getChangedFiles();
+	}
 }

--- a/src/main/java/team/po/feature/teamspace/repository/ProjectGroupGithubRepositoryRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/ProjectGroupGithubRepositoryRepository.java
@@ -1,6 +1,7 @@
 package team.po.feature.teamspace.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,9 @@ public interface ProjectGroupGithubRepositoryRepository extends JpaRepository<Pr
 	long countByProjectGroup_IdAndDeletedAtIsNull(Long projectGroupId);
 
 	List<ProjectGroupGithubRepository> findAllByProjectGroup_IdAndDeletedAtIsNull(Long projectGroupId);
+
+	Optional<ProjectGroupGithubRepository> findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		Long projectGroupId,
+		Long githubRepositoryId
+	);
 }

--- a/src/main/java/team/po/feature/teamspace/repository/ProjectGroupGithubRepositoryRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/ProjectGroupGithubRepositoryRepository.java
@@ -4,8 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import team.po.feature.teamspace.domain.ProjectGroupGithubRepository;
+import team.po.feature.teamspace.dto.GithubPullRequestSyncContext;
 
 public interface ProjectGroupGithubRepositoryRepository extends JpaRepository<ProjectGroupGithubRepository, Long> {
 	long countByProjectGroup_IdAndDeletedAtIsNull(Long projectGroupId);
@@ -15,5 +18,22 @@ public interface ProjectGroupGithubRepositoryRepository extends JpaRepository<Pr
 	Optional<ProjectGroupGithubRepository> findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
 		Long projectGroupId,
 		Long githubRepositoryId
+	);
+
+	@Query("""
+		SELECT new team.po.feature.teamspace.dto.GithubPullRequestSyncContext(
+			installation.installationId,
+			repository.owner,
+			repository.repoName
+		)
+		FROM ProjectGroupGithubRepository repository
+		JOIN repository.githubInstallation installation
+		WHERE repository.projectGroup.id = :projectGroupId
+			AND repository.githubRepositoryId = :githubRepositoryId
+			AND repository.deletedAt IS NULL
+		""")
+	Optional<GithubPullRequestSyncContext> findGithubPullRequestSyncContext(
+		@Param("projectGroupId") Long projectGroupId,
+		@Param("githubRepositoryId") Long githubRepositoryId
 	);
 }

--- a/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
+++ b/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
@@ -3,7 +3,11 @@ package team.po.feature.teamspace.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -31,6 +35,11 @@ public class GithubAppClient {
 	private static final String ORGANIZATION_MEMBERSHIP_ADMIN_ROLE = "admin";
 	private static final int REPOSITORY_PAGE_SIZE = 100;
 	private static final int PULL_REQUEST_PAGE_SIZE = 100;
+	private static final Pattern CLOSING_ISSUE_REFERENCES_PATTERN = Pattern.compile(
+		"(?i)\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\b\\s+"
+			+ "((?:(?:[\\w.-]+/[\\w.-]+)?#\\d+)(?:\\s*(?:,|and)\\s*(?:(?:[\\w.-]+/[\\w.-]+)?#\\d+))*)"
+	);
+	private static final Pattern ISSUE_REFERENCE_PATTERN = Pattern.compile("(?:[\\w.-]+/[\\w.-]+)?#\\d+");
 
 	private final RestClient restClient;
 	private final GithubAppJwtProvider githubAppJwtProvider;
@@ -149,6 +158,7 @@ public class GithubAppClient {
 			response.additions(),
 			response.deletions(),
 			response.changedFiles(),
+			countLinkedIssues(response.body()),
 			response.htmlUrl()
 		));
 	}
@@ -319,6 +329,23 @@ public class GithubAppClient {
 			&& !pullRequest.user().login().isBlank();
 	}
 
+	private int countLinkedIssues(String pullRequestBody) {
+		if (pullRequestBody == null || pullRequestBody.isBlank()) {
+			return 0;
+		}
+
+		Set<String> issueReferences = new HashSet<>();
+		Matcher closingIssueReferencesMatcher = CLOSING_ISSUE_REFERENCES_PATTERN.matcher(pullRequestBody);
+		while (closingIssueReferencesMatcher.find()) {
+			Matcher issueReferenceMatcher = ISSUE_REFERENCE_PATTERN.matcher(closingIssueReferencesMatcher.group(1));
+			while (issueReferenceMatcher.find()) {
+				issueReferences.add(issueReferenceMatcher.group().toLowerCase());
+			}
+		}
+
+		return issueReferences.size();
+	}
+
 	public record GithubAppInstallationInfo(
 		Long installationId,
 		Long accountId,
@@ -396,6 +423,7 @@ public class GithubAppClient {
 		Integer deletions,
 		@JsonProperty("changed_files")
 		Integer changedFiles,
+		String body,
 		@JsonProperty("html_url")
 		String htmlUrl
 	) {

--- a/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
+++ b/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
@@ -2,6 +2,7 @@ package team.po.feature.teamspace.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.time.Instant;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import team.po.config.GithubAppProperties;
 import team.po.exception.ApplicationException;
 import team.po.exception.ErrorCode;
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
+import team.po.feature.teamspace.dto.GithubPullRequestSummary;
 import team.po.feature.teamspace.provider.GithubAppJwtProvider;
 
 @RequiredArgsConstructor
@@ -26,6 +29,7 @@ public class GithubAppClient {
 	private static final String ORGANIZATION_MEMBERSHIP_ACTIVE_STATE = "active";
 	private static final String ORGANIZATION_MEMBERSHIP_ADMIN_ROLE = "admin";
 	private static final int REPOSITORY_PAGE_SIZE = 100;
+	private static final int PULL_REQUEST_PAGE_SIZE = 100;
 
 	private final RestClient restClient;
 	private final GithubAppJwtProvider githubAppJwtProvider;
@@ -90,6 +94,58 @@ public class GithubAppClient {
 			}
 			page++;
 		}
+	}
+
+	public List<GithubPullRequestSummary> getClosedPullRequests(Long installationId, String owner, String repoName) {
+		String accessToken = createInstallationAccessToken(installationId);
+		List<GithubPullRequestSummary> pullRequests = new ArrayList<>();
+		int page = 1;
+
+		while (true) {
+			List<GithubPullRequestResponse> response = getClosedPullRequests(accessToken, owner, repoName, page);
+
+			response.stream()
+				.map(pullRequest -> new GithubPullRequestSummary(
+					pullRequest.id(),
+					pullRequest.number(),
+					pullRequest.title(),
+					pullRequest.user().id(),
+					pullRequest.user().login(),
+					pullRequest.state(),
+					pullRequest.mergedAt(),
+					pullRequest.htmlUrl()
+				))
+				.forEach(pullRequests::add);
+
+			if (response.size() < PULL_REQUEST_PAGE_SIZE) {
+				return pullRequests;
+			}
+			page++;
+		}
+	}
+
+	public GithubPullRequestInfo getPullRequest(
+		Long installationId,
+		String owner,
+		String repoName,
+		Long pullNumber
+	) {
+		String accessToken = createInstallationAccessToken(installationId);
+		GithubPullRequestResponse response = getPullRequest(accessToken, owner, repoName, pullNumber);
+
+		return new GithubPullRequestInfo(
+			response.id(),
+			response.number(),
+			response.title(),
+			response.user().id(),
+			response.user().login(),
+			response.state(),
+			response.mergedAt(),
+			response.additions(),
+			response.deletions(),
+			response.changedFiles(),
+			response.htmlUrl()
+		);
 	}
 
 	public void validateOrganizationAdmin(String accessToken, String organizationLogin) {
@@ -185,6 +241,72 @@ public class GithubAppClient {
 		}
 	}
 
+	private List<GithubPullRequestResponse> getClosedPullRequests(
+		String accessToken,
+		String owner,
+		String repoName,
+		int page
+	) {
+		try {
+			List<GithubPullRequestResponse> response = restClient.get()
+				.uri(UriComponentsBuilder
+					.fromUriString(githubAppProperties.apiBaseUrl())
+					.pathSegment("repos", owner, repoName, "pulls")
+					.queryParam("state", "closed")
+					.queryParam("per_page", PULL_REQUEST_PAGE_SIZE)
+					.queryParam("page", page)
+					.build()
+					.toUriString())
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.header(HttpHeaders.ACCEPT, "application/vnd.github+json")
+				.header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+				.retrieve()
+				.body(new org.springframework.core.ParameterizedTypeReference<>() {
+				});
+
+			if (response == null) {
+				throw new ApplicationException(ErrorCode.GITHUB_API_REQUEST_FAILED);
+			}
+
+			return response;
+		} catch (ApplicationException exception) {
+			throw exception;
+		} catch (RestClientException exception) {
+			throw new ApplicationException(ErrorCode.GITHUB_API_REQUEST_FAILED, exception);
+		}
+	}
+
+	private GithubPullRequestResponse getPullRequest(
+		String accessToken,
+		String owner,
+		String repoName,
+		Long pullNumber
+	) {
+		try {
+			GithubPullRequestResponse response = restClient.get()
+				.uri(UriComponentsBuilder
+					.fromUriString(githubAppProperties.apiBaseUrl())
+					.pathSegment("repos", owner, repoName, "pulls", String.valueOf(pullNumber))
+					.build()
+					.toUriString())
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.header(HttpHeaders.ACCEPT, "application/vnd.github+json")
+				.header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+				.retrieve()
+				.body(GithubPullRequestResponse.class);
+
+			if (response == null || response.user() == null) {
+				throw new ApplicationException(ErrorCode.GITHUB_API_REQUEST_FAILED);
+			}
+
+			return response;
+		} catch (ApplicationException exception) {
+			throw exception;
+		} catch (RestClientException exception) {
+			throw new ApplicationException(ErrorCode.GITHUB_API_REQUEST_FAILED, exception);
+		}
+	}
+
 	public record GithubAppInstallationInfo(
 		Long installationId,
 		Long accountId,
@@ -246,6 +368,29 @@ public class GithubAppClient {
 	}
 
 	private record GithubRepositoryOwnerResponse(
+		String login
+	) {
+	}
+
+	private record GithubPullRequestResponse(
+		Long id,
+		Long number,
+		String title,
+		GithubPullRequestUserResponse user,
+		String state,
+		@JsonProperty("merged_at")
+		Instant mergedAt,
+		Integer additions,
+		Integer deletions,
+		@JsonProperty("changed_files")
+		Integer changedFiles,
+		@JsonProperty("html_url")
+		String htmlUrl
+	) {
+	}
+
+	private record GithubPullRequestUserResponse(
+		Long id,
 		String login
 	) {
 	}

--- a/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
+++ b/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
@@ -107,7 +107,32 @@ public class GithubAppClient {
 	}
 
 	public List<GithubPullRequestSummary> getClosedPullRequests(Long installationId, String owner, String repoName) {
-		String accessToken = createInstallationAccessToken(installationId);
+		return createPullRequestSyncSession(installationId).getClosedPullRequests(owner, repoName);
+	}
+
+	public GithubPullRequestSyncSession createPullRequestSyncSession(Long installationId) {
+		return new InstallationTokenPullRequestSyncSession(createInstallationAccessToken(installationId));
+	}
+
+	private class InstallationTokenPullRequestSyncSession implements GithubPullRequestSyncSession {
+		private final String accessToken;
+
+		private InstallationTokenPullRequestSyncSession(String accessToken) {
+			this.accessToken = accessToken;
+		}
+
+		@Override
+		public List<GithubPullRequestSummary> getClosedPullRequests(String owner, String repoName) {
+			return GithubAppClient.this.getClosedPullRequests(accessToken, owner, repoName);
+		}
+
+		@Override
+		public Optional<GithubPullRequestInfo> getPullRequest(String owner, String repoName, Long pullNumber) {
+			return GithubAppClient.this.getPullRequest(accessToken, owner, repoName, pullNumber);
+		}
+	}
+
+	private List<GithubPullRequestSummary> getClosedPullRequests(String accessToken, String owner, String repoName) {
 		List<GithubPullRequestSummary> pullRequests = new ArrayList<>();
 		int page = 1;
 
@@ -141,8 +166,16 @@ public class GithubAppClient {
 		String repoName,
 		Long pullNumber
 	) {
-		String accessToken = createInstallationAccessToken(installationId);
-		GithubPullRequestResponse response = getPullRequest(accessToken, owner, repoName, pullNumber);
+		return createPullRequestSyncSession(installationId).getPullRequest(owner, repoName, pullNumber);
+	}
+
+	private Optional<GithubPullRequestInfo> getPullRequest(
+		String accessToken,
+		String owner,
+		String repoName,
+		Long pullNumber
+	) {
+		GithubPullRequestResponse response = requestPullRequest(accessToken, owner, repoName, pullNumber);
 		if (!hasGithubUser(response)) {
 			return Optional.empty();
 		}
@@ -291,7 +324,7 @@ public class GithubAppClient {
 		}
 	}
 
-	private GithubPullRequestResponse getPullRequest(
+	private GithubPullRequestResponse requestPullRequest(
 		String accessToken,
 		String owner,
 		String repoName,

--- a/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
+++ b/src/main/java/team/po/feature/teamspace/service/GithubAppClient.java
@@ -3,6 +3,7 @@ package team.po.feature.teamspace.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.time.Instant;
+import java.util.Optional;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -105,6 +106,7 @@ public class GithubAppClient {
 			List<GithubPullRequestResponse> response = getClosedPullRequests(accessToken, owner, repoName, page);
 
 			response.stream()
+				.filter(this::hasGithubUser)
 				.map(pullRequest -> new GithubPullRequestSummary(
 					pullRequest.id(),
 					pullRequest.number(),
@@ -124,7 +126,7 @@ public class GithubAppClient {
 		}
 	}
 
-	public GithubPullRequestInfo getPullRequest(
+	public Optional<GithubPullRequestInfo> getPullRequest(
 		Long installationId,
 		String owner,
 		String repoName,
@@ -132,8 +134,11 @@ public class GithubAppClient {
 	) {
 		String accessToken = createInstallationAccessToken(installationId);
 		GithubPullRequestResponse response = getPullRequest(accessToken, owner, repoName, pullNumber);
+		if (!hasGithubUser(response)) {
+			return Optional.empty();
+		}
 
-		return new GithubPullRequestInfo(
+		return Optional.of(new GithubPullRequestInfo(
 			response.id(),
 			response.number(),
 			response.title(),
@@ -145,7 +150,7 @@ public class GithubAppClient {
 			response.deletions(),
 			response.changedFiles(),
 			response.htmlUrl()
-		);
+		));
 	}
 
 	public void validateOrganizationAdmin(String accessToken, String organizationLogin) {
@@ -295,7 +300,7 @@ public class GithubAppClient {
 				.retrieve()
 				.body(GithubPullRequestResponse.class);
 
-			if (response == null || response.user() == null) {
+			if (response == null) {
 				throw new ApplicationException(ErrorCode.GITHUB_API_REQUEST_FAILED);
 			}
 
@@ -305,6 +310,13 @@ public class GithubAppClient {
 		} catch (RestClientException exception) {
 			throw new ApplicationException(ErrorCode.GITHUB_API_REQUEST_FAILED, exception);
 		}
+	}
+
+	private boolean hasGithubUser(GithubPullRequestResponse pullRequest) {
+		return pullRequest.user() != null
+			&& pullRequest.user().id() != null
+			&& pullRequest.user().login() != null
+			&& !pullRequest.user().login().isBlank();
 	}
 
 	public record GithubAppInstallationInfo(

--- a/src/main/java/team/po/feature/teamspace/service/GithubPullRequestSyncSession.java
+++ b/src/main/java/team/po/feature/teamspace/service/GithubPullRequestSyncSession.java
@@ -1,0 +1,13 @@
+package team.po.feature.teamspace.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
+import team.po.feature.teamspace.dto.GithubPullRequestSummary;
+
+public interface GithubPullRequestSyncSession {
+	List<GithubPullRequestSummary> getClosedPullRequests(String owner, String repoName);
+
+	Optional<GithubPullRequestInfo> getPullRequest(String owner, String repoName, Long pullNumber);
+}

--- a/src/main/java/team/po/feature/teamspace/service/TeamspacePersistenceTxService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspacePersistenceTxService.java
@@ -153,13 +153,18 @@ public class TeamspacePersistenceTxService {
 			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_GROUP_NOT_FOUND));
 
 		List<GithubPullRequestContribution> newContributions = pullRequests.stream()
-			.map(pullRequest -> upsertGithubPullRequestContribution(
-				projectGroupId,
+			.filter(pullRequest -> githubPullRequestContributionRepository
+				.findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(
+					projectGroupId,
+					githubRepositoryId,
+					pullRequest.githubPullRequestId()
+				)
+				.isEmpty())
+			.map(pullRequest -> createGithubPullRequestContribution(
 				projectGroup,
 				githubRepositoryId,
 				pullRequest
 			))
-			.filter(contribution -> contribution.getId() == null)
 			.toList();
 
 		if (newContributions.isEmpty()) {
@@ -169,53 +174,29 @@ public class TeamspacePersistenceTxService {
 		githubPullRequestContributionRepository.saveAll(newContributions);
 	}
 
-	private GithubPullRequestContribution upsertGithubPullRequestContribution(
-		Long projectGroupId,
+	private GithubPullRequestContribution createGithubPullRequestContribution(
 		ProjectGroup projectGroup,
 		Long githubRepositoryId,
 		GithubPullRequestInfo pullRequest
 	) {
-		return githubPullRequestContributionRepository
-			.findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(
-				projectGroupId,
-				githubRepositoryId,
-				pullRequest.githubPullRequestId()
-			)
-			.map(existingContribution -> {
-				existingContribution.updatePullRequestContribution(
-					pullRequest.title(),
-					pullRequest.authorGithubUserId(),
-					pullRequest.authorGithubUsername(),
-					pullRequest.state(),
-					pullRequest.mergedAt() != null,
-					pullRequest.mergedAt(),
-					toNonNegativeInt(pullRequest.additions()),
-					toNonNegativeInt(pullRequest.deletions()),
-					toNonNegativeInt(pullRequest.changedFiles()),
-					toNonNegativeInt(pullRequest.linkedIssueCount()),
-					pullRequest.htmlUrl(),
-					Instant.now()
-				);
-				return existingContribution;
-			})
-			.orElseGet(() -> GithubPullRequestContribution.builder()
-				.projectGroup(projectGroup)
-				.githubRepositoryId(githubRepositoryId)
-				.githubPrId(pullRequest.githubPullRequestId())
-				.prNumber(pullRequest.pullNumber())
-				.title(pullRequest.title())
-				.authorGithubUserId(pullRequest.authorGithubUserId())
-				.authorGithubUsername(pullRequest.authorGithubUsername())
-				.state(pullRequest.state())
-				.merged(pullRequest.mergedAt() != null)
-				.mergedAt(pullRequest.mergedAt())
-				.additions(toNonNegativeInt(pullRequest.additions()))
-				.deletions(toNonNegativeInt(pullRequest.deletions()))
-				.changedFiles(toNonNegativeInt(pullRequest.changedFiles()))
-				.linkedIssueCount(toNonNegativeInt(pullRequest.linkedIssueCount()))
-				.htmlUrl(pullRequest.htmlUrl())
-				.syncedAt(Instant.now())
-				.build());
+		return GithubPullRequestContribution.builder()
+			.projectGroup(projectGroup)
+			.githubRepositoryId(githubRepositoryId)
+			.githubPrId(pullRequest.githubPullRequestId())
+			.prNumber(pullRequest.pullNumber())
+			.title(pullRequest.title())
+			.authorGithubUserId(pullRequest.authorGithubUserId())
+			.authorGithubUsername(pullRequest.authorGithubUsername())
+			.state(pullRequest.state())
+			.merged(pullRequest.mergedAt() != null)
+			.mergedAt(pullRequest.mergedAt())
+			.additions(toNonNegativeInt(pullRequest.additions()))
+			.deletions(toNonNegativeInt(pullRequest.deletions()))
+			.changedFiles(toNonNegativeInt(pullRequest.changedFiles()))
+			.linkedIssueCount(toNonNegativeInt(pullRequest.linkedIssueCount()))
+			.htmlUrl(pullRequest.htmlUrl())
+			.syncedAt(Instant.now())
+			.build();
 	}
 
 	private int toNonNegativeInt(Integer value) {

--- a/src/main/java/team/po/feature/teamspace/service/TeamspacePersistenceTxService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspacePersistenceTxService.java
@@ -19,10 +19,13 @@ import team.po.feature.projectgroup.domain.ProjectGroup;
 import team.po.feature.projectgroup.repository.ProjectGroupMemberRepository;
 import team.po.feature.projectgroup.repository.ProjectGroupRepository;
 import team.po.feature.teamspace.domain.GithubInstallation;
+import team.po.feature.teamspace.domain.GithubPullRequestContribution;
 import team.po.feature.teamspace.domain.ProjectGroupGithubInstallation;
 import team.po.feature.teamspace.domain.ProjectGroupGithubRepository;
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
+import team.po.feature.teamspace.repository.GithubPullRequestContributionRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubInstallationRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubRepositoryRepository;
 
@@ -35,6 +38,7 @@ public class TeamspacePersistenceTxService {
 	private final ProjectGroupGithubInstallationRepository projectGroupGithubInstallationRepository;
 	private final ProjectGroupGithubRepositoryRepository projectGroupGithubRepositoryRepository;
 	private final GithubInstallationRepository githubInstallationRepository;
+	private final GithubPullRequestContributionRepository githubPullRequestContributionRepository;
 
 	@Transactional(readOnly = true)
 	public GithubRepositorySettingContext prepareGithubRepositorySetting(Long projectGroupId, Long requesterUserId) {
@@ -137,6 +141,88 @@ public class TeamspacePersistenceTxService {
 			.toList();
 
 		projectGroupGithubRepositoryRepository.saveAll(selectedRepositories);
+	}
+
+	@Transactional
+	public void persistGithubPullRequestContributions(
+		Long projectGroupId,
+		Long githubRepositoryId,
+		List<GithubPullRequestInfo> pullRequests
+	) {
+		ProjectGroup projectGroup = projectGroupRepository.findByIdForUpdate(projectGroupId)
+			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_GROUP_NOT_FOUND));
+
+		List<GithubPullRequestContribution> newContributions = pullRequests.stream()
+			.map(pullRequest -> upsertGithubPullRequestContribution(
+				projectGroupId,
+				projectGroup,
+				githubRepositoryId,
+				pullRequest
+			))
+			.filter(contribution -> contribution.getId() == null)
+			.toList();
+
+		if (newContributions.isEmpty()) {
+			return;
+		}
+
+		githubPullRequestContributionRepository.saveAll(newContributions);
+	}
+
+	private GithubPullRequestContribution upsertGithubPullRequestContribution(
+		Long projectGroupId,
+		ProjectGroup projectGroup,
+		Long githubRepositoryId,
+		GithubPullRequestInfo pullRequest
+	) {
+		return githubPullRequestContributionRepository
+			.findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(
+				projectGroupId,
+				githubRepositoryId,
+				pullRequest.githubPullRequestId()
+			)
+			.map(existingContribution -> {
+				existingContribution.updatePullRequestContribution(
+					pullRequest.title(),
+					pullRequest.authorGithubUserId(),
+					pullRequest.authorGithubUsername(),
+					pullRequest.state(),
+					pullRequest.mergedAt() != null,
+					pullRequest.mergedAt(),
+					toNonNegativeInt(pullRequest.additions()),
+					toNonNegativeInt(pullRequest.deletions()),
+					toNonNegativeInt(pullRequest.changedFiles()),
+					0,
+					pullRequest.htmlUrl(),
+					Instant.now()
+				);
+				return existingContribution;
+			})
+			.orElseGet(() -> GithubPullRequestContribution.builder()
+				.projectGroup(projectGroup)
+				.githubRepositoryId(githubRepositoryId)
+				.githubPrId(pullRequest.githubPullRequestId())
+				.prNumber(pullRequest.pullNumber())
+				.title(pullRequest.title())
+				.authorGithubUserId(pullRequest.authorGithubUserId())
+				.authorGithubUsername(pullRequest.authorGithubUsername())
+				.state(pullRequest.state())
+				.merged(pullRequest.mergedAt() != null)
+				.mergedAt(pullRequest.mergedAt())
+				.additions(toNonNegativeInt(pullRequest.additions()))
+				.deletions(toNonNegativeInt(pullRequest.deletions()))
+				.changedFiles(toNonNegativeInt(pullRequest.changedFiles()))
+				.linkedIssueCount(0)
+				.htmlUrl(pullRequest.htmlUrl())
+				.syncedAt(Instant.now())
+				.build());
+	}
+
+	private int toNonNegativeInt(Integer value) {
+		if (value == null) {
+			return 0;
+		}
+		return Math.max(value, 0);
 	}
 
 	private void validateProjectGroupHost(Long projectGroupId, Long requesterUserId) {

--- a/src/main/java/team/po/feature/teamspace/service/TeamspacePersistenceTxService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspacePersistenceTxService.java
@@ -192,7 +192,7 @@ public class TeamspacePersistenceTxService {
 					toNonNegativeInt(pullRequest.additions()),
 					toNonNegativeInt(pullRequest.deletions()),
 					toNonNegativeInt(pullRequest.changedFiles()),
-					0,
+					toNonNegativeInt(pullRequest.linkedIssueCount()),
 					pullRequest.htmlUrl(),
 					Instant.now()
 				);
@@ -212,7 +212,7 @@ public class TeamspacePersistenceTxService {
 				.additions(toNonNegativeInt(pullRequest.additions()))
 				.deletions(toNonNegativeInt(pullRequest.deletions()))
 				.changedFiles(toNonNegativeInt(pullRequest.changedFiles()))
-				.linkedIssueCount(0)
+				.linkedIssueCount(toNonNegativeInt(pullRequest.linkedIssueCount()))
 				.htmlUrl(pullRequest.htmlUrl())
 				.syncedAt(Instant.now())
 				.build());

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -2,7 +2,9 @@ package team.po.feature.teamspace.service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -247,17 +249,31 @@ public class TeamspaceService {
 			));
 
 		Long installationId = repository.getGithubInstallation().getInstallationId();
-		List<GithubPullRequestInfo> mergedPullRequests = githubAppClient
+		List<GithubPullRequestSummary> mergedPullRequestSummaries = githubAppClient
 			.getClosedPullRequests(installationId, repository.getOwner(), repository.getRepoName())
 			.stream()
 			.filter(pullRequest -> pullRequest.mergedAt() != null)
+			.toList();
+		Set<Long> mergedGithubPrIds = mergedPullRequestSummaries.stream()
+			.map(GithubPullRequestSummary::githubPullRequestId)
+			.collect(Collectors.toSet());
+		Set<Long> existingGithubPrIds = mergedGithubPrIds.isEmpty()
+			? Set.of()
+			: githubPullRequestContributionRepository.findExistingGithubPrIds(
+				projectGroupId,
+				githubRepositoryId,
+				mergedGithubPrIds
+			);
+
+		List<GithubPullRequestInfo> newMergedPullRequests = mergedPullRequestSummaries.stream()
+			.filter(pullRequest -> !existingGithubPrIds.contains(pullRequest.githubPullRequestId()))
 			.map(pullRequest -> getPullRequestDetail(installationId, repository, pullRequest))
 			.toList();
 
 		teamspacePersistenceTxService.persistGithubPullRequestContributions(
 			projectGroupId,
 			githubRepositoryId,
-			mergedPullRequests
+			newMergedPullRequests
 		);
 	}
 

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -27,6 +27,8 @@ import team.po.feature.teamspace.dto.GetAvailableGithubRepositoryList;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
+import team.po.feature.teamspace.dto.GithubPullRequestSummary;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubInstallationRepository;
@@ -191,6 +193,47 @@ public class TeamspaceService {
 			context.githubInstallationId(),
 			request.githubRepositoryIds(),
 			repositories
+		);
+	}
+
+	public void syncGithubPullRequestContributions(Long projectGroupId, Long githubRepositoryId) {
+		ProjectGroupGithubRepository repository = projectGroupGithubRepositoryRepository
+			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(projectGroupId, githubRepositoryId)
+			.orElseThrow(() -> new ApplicationException(
+				ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE,
+				"팀 스페이스에 등록된 Github Repository가 아닙니다."
+			));
+
+		Long installationId = repository.getGithubInstallation().getInstallationId();
+		List<GithubPullRequestInfo> mergedPullRequests = githubAppClient
+			.getClosedPullRequests(installationId, repository.getOwner(), repository.getRepoName())
+			.stream()
+			.filter(pullRequest -> pullRequest.mergedAt() != null)
+			.map(pullRequest -> getPullRequestDetail(installationId, repository, pullRequest))
+			.toList();
+
+		teamspacePersistenceTxService.persistGithubPullRequestContributions(
+			projectGroupId,
+			githubRepositoryId,
+			mergedPullRequests
+		);
+	}
+
+	public void syncGithubPullRequestContributions(Users user, Long projectGroupId, Long githubRepositoryId) {
+		validateProjectGroupHost(projectGroupId, user.getId());
+		syncGithubPullRequestContributions(projectGroupId, githubRepositoryId);
+	}
+
+	private GithubPullRequestInfo getPullRequestDetail(
+		Long installationId,
+		ProjectGroupGithubRepository repository,
+		GithubPullRequestSummary pullRequest
+	) {
+		return githubAppClient.getPullRequest(
+			installationId,
+			repository.getOwner(),
+			repository.getRepoName(),
+			pullRequest.pullNumber()
 		);
 	}
 

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -26,11 +26,13 @@ import team.po.feature.teamspace.dto.CreateGithubAppInstallationUrlResponse;
 import team.po.feature.teamspace.dto.GetAvailableGithubRepositoryList;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
+import team.po.feature.teamspace.dto.GetGithubRepositoryContributionResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
 import team.po.feature.teamspace.dto.GithubPullRequestInfo;
 import team.po.feature.teamspace.dto.GithubPullRequestSummary;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
+import team.po.feature.teamspace.repository.GithubPullRequestContributionRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubInstallationRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubRepositoryRepository;
 import team.po.feature.user.domain.GithubAccount;
@@ -60,6 +62,7 @@ public class TeamspaceService {
 	private final GithubAppClient githubAppClient;
 	private final GithubTokenEncryptor githubTokenEncryptor;
 	private final TeamspacePersistenceTxService teamspacePersistenceTxService;
+	private final GithubPullRequestContributionRepository githubPullRequestContributionRepository;
 
 	@Transactional(readOnly = true)
 	public GetGithubInstallationStatusResponse getGithubInstallationStatus(Long projectGroupId, Long requesterUserId) {
@@ -170,6 +173,44 @@ public class TeamspaceService {
 			.toList());
 	}
 
+	@Transactional(readOnly = true)
+	public GetGithubRepositoryContributionResponse getGithubRepositoryContributions(
+		Users user,
+		Long projectGroupId,
+		Long githubRepositoryId
+	) {
+		validateProjectGroupMember(projectGroupId, user.getId());
+		ProjectGroupGithubRepository repository = projectGroupGithubRepositoryRepository
+			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(projectGroupId, githubRepositoryId)
+			.orElseThrow(() -> new ApplicationException(
+				ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE,
+				"팀 스페이스에 등록된 Github Repository가 아닙니다."
+			));
+
+		List<GetGithubRepositoryContributionResponse.ContributorResponse> contributors =
+			githubPullRequestContributionRepository
+				.findContributionSummaries(projectGroupId, githubRepositoryId)
+				.stream()
+				.map(summary -> new GetGithubRepositoryContributionResponse.ContributorResponse(
+					summary.getGithubUserId(),
+					summary.getGithubUsername(),
+					summary.getMergedPrCount(),
+					summary.getLinkedIssueCount(),
+					summary.getAdditions(),
+					summary.getDeletions(),
+					summary.getChangedFiles(),
+					calculateContributionScore(summary.getMergedPrCount(), summary.getLinkedIssueCount())
+				))
+				.toList();
+
+		return new GetGithubRepositoryContributionResponse(
+			repository.getGithubRepositoryId(),
+			repository.getRepoName(),
+			repository.getFullName(),
+			contributors
+		);
+	}
+
 	public void setGithubRepositoryList(Users user, Long projectGroupId, SetGithubRepositoryListRequest request) {
 		GithubRepositorySettingContext context = teamspacePersistenceTxService.prepareGithubRepositorySetting(
 			projectGroupId,
@@ -235,6 +276,10 @@ public class TeamspaceService {
 			repository.getRepoName(),
 			pullRequest.pullNumber()
 		);
+	}
+
+	private long calculateContributionScore(long mergedPrCount, long linkedIssueCount) {
+		return mergedPrCount * 10 + linkedIssueCount * 5;
 	}
 
 	private void validateRequesterCanConnectOrganization(Long requesterUserId, String organizationLogin) {

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -192,6 +192,7 @@ public class TeamspaceService {
 				.findContributionSummaries(projectGroupId, githubRepositoryId)
 				.stream()
 				.map(summary -> new GetGithubRepositoryContributionResponse.ContributorResponse(
+					summary.getUserId(),
 					summary.getGithubUserId(),
 					summary.getGithubUsername(),
 					summary.getMergedPrCount(),

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -1,6 +1,7 @@
 package team.po.feature.teamspace.service;
 
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -52,6 +53,7 @@ public class TeamspaceService {
 	private static final String GITHUB_APP_INSTALLATION_BASE_URL = "https://github.com/apps";
 	private static final String GITHUB_APP_INSTALLATION_STATE_DELIMITER = "|";
 	private static final String GITHUB_APP_SETUP_ACTION_INSTALL = "install";
+	private static final int EXISTING_GITHUB_PR_ID_QUERY_CHUNK_SIZE = 500;
 
 	private final ProjectGroupMemberRepository projectGroupMemberRepository;
 	private final ProjectGroupGithubInstallationRepository projectGroupGithubInstallationRepository;
@@ -260,13 +262,11 @@ public class TeamspaceService {
 		Set<Long> mergedGithubPrIds = mergedPullRequestSummaries.stream()
 			.map(GithubPullRequestSummary::githubPullRequestId)
 			.collect(Collectors.toSet());
-		Set<Long> existingGithubPrIds = mergedGithubPrIds.isEmpty()
-			? Set.of()
-			: githubPullRequestContributionRepository.findExistingGithubPrIds(
-				projectGroupId,
-				githubRepositoryId,
-				mergedGithubPrIds
-			);
+		Set<Long> existingGithubPrIds = findExistingGithubPrIdsInChunks(
+			projectGroupId,
+			githubRepositoryId,
+			mergedGithubPrIds
+		);
 
 		List<GithubPullRequestInfo> newMergedPullRequests = mergedPullRequestSummaries.stream()
 			.filter(pullRequest -> !existingGithubPrIds.contains(pullRequest.githubPullRequestId()))
@@ -296,6 +296,29 @@ public class TeamspaceService {
 			repository.getRepoName(),
 			pullRequest.pullNumber()
 		);
+	}
+
+	private Set<Long> findExistingGithubPrIdsInChunks(
+		Long projectGroupId,
+		Long githubRepositoryId,
+		Set<Long> githubPrIds
+	) {
+		if (githubPrIds.isEmpty()) {
+			return Set.of();
+		}
+
+		List<Long> githubPrIdList = githubPrIds.stream().toList();
+		Set<Long> existingGithubPrIds = new HashSet<>();
+		for (int start = 0; start < githubPrIdList.size(); start += EXISTING_GITHUB_PR_ID_QUERY_CHUNK_SIZE) {
+			int end = Math.min(start + EXISTING_GITHUB_PR_ID_QUERY_CHUNK_SIZE, githubPrIdList.size());
+			existingGithubPrIds.addAll(githubPullRequestContributionRepository.findExistingGithubPrIds(
+				projectGroupId,
+				githubRepositoryId,
+				Set.copyOf(githubPrIdList.subList(start, end))
+			));
+		}
+
+		return existingGithubPrIds;
 	}
 
 	private long calculateContributionScore(long mergedPrCount, long linkedIssueCount) {

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -250,8 +250,10 @@ public class TeamspaceService {
 			));
 
 		Long installationId = repository.getGithubInstallation().getInstallationId();
-		List<GithubPullRequestSummary> mergedPullRequestSummaries = githubAppClient
-			.getClosedPullRequests(installationId, repository.getOwner(), repository.getRepoName())
+		GithubPullRequestSyncSession pullRequestSyncSession = githubAppClient
+			.createPullRequestSyncSession(installationId);
+		List<GithubPullRequestSummary> mergedPullRequestSummaries = pullRequestSyncSession
+			.getClosedPullRequests(repository.getOwner(), repository.getRepoName())
 			.stream()
 			.filter(pullRequest -> pullRequest.mergedAt() != null)
 			.toList();
@@ -268,7 +270,7 @@ public class TeamspaceService {
 
 		List<GithubPullRequestInfo> newMergedPullRequests = mergedPullRequestSummaries.stream()
 			.filter(pullRequest -> !existingGithubPrIds.contains(pullRequest.githubPullRequestId()))
-			.map(pullRequest -> getPullRequestDetail(installationId, repository, pullRequest))
+			.map(pullRequest -> getPullRequestDetail(pullRequestSyncSession, repository, pullRequest))
 			.flatMap(Optional::stream)
 			.toList();
 
@@ -285,12 +287,11 @@ public class TeamspaceService {
 	}
 
 	private Optional<GithubPullRequestInfo> getPullRequestDetail(
-		Long installationId,
+		GithubPullRequestSyncSession pullRequestSyncSession,
 		ProjectGroupGithubRepository repository,
 		GithubPullRequestSummary pullRequest
 	) {
-		return githubAppClient.getPullRequest(
-			installationId,
+		return pullRequestSyncSession.getPullRequest(
 			repository.getOwner(),
 			repository.getRepoName(),
 			pullRequest.pullNumber()

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -34,6 +34,7 @@ import team.po.feature.teamspace.dto.GetGithubRepositoryContributionResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
 import team.po.feature.teamspace.dto.GithubPullRequestInfo;
 import team.po.feature.teamspace.dto.GithubPullRequestSummary;
+import team.po.feature.teamspace.dto.GithubPullRequestSyncContext;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
 import team.po.feature.teamspace.repository.GithubPullRequestContributionRepository;
@@ -244,18 +245,17 @@ public class TeamspaceService {
 	}
 
 	public void syncGithubPullRequestContributions(Long projectGroupId, Long githubRepositoryId) {
-		ProjectGroupGithubRepository repository = projectGroupGithubRepositoryRepository
-			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(projectGroupId, githubRepositoryId)
+		GithubPullRequestSyncContext context = projectGroupGithubRepositoryRepository
+			.findGithubPullRequestSyncContext(projectGroupId, githubRepositoryId)
 			.orElseThrow(() -> new ApplicationException(
 				ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE,
 				"팀 스페이스에 등록된 Github Repository가 아닙니다."
 			));
 
-		Long installationId = repository.getGithubInstallation().getInstallationId();
 		GithubPullRequestSyncSession pullRequestSyncSession = githubAppClient
-			.createPullRequestSyncSession(installationId);
+			.createPullRequestSyncSession(context.installationId());
 		List<GithubPullRequestSummary> mergedPullRequestSummaries = pullRequestSyncSession
-			.getClosedPullRequests(repository.getOwner(), repository.getRepoName())
+			.getClosedPullRequests(context.owner(), context.repoName())
 			.stream()
 			.filter(pullRequest -> pullRequest.mergedAt() != null)
 			.toList();
@@ -270,7 +270,7 @@ public class TeamspaceService {
 
 		List<GithubPullRequestInfo> newMergedPullRequests = mergedPullRequestSummaries.stream()
 			.filter(pullRequest -> !existingGithubPrIds.contains(pullRequest.githubPullRequestId()))
-			.map(pullRequest -> getPullRequestDetail(pullRequestSyncSession, repository, pullRequest))
+			.map(pullRequest -> getPullRequestDetail(pullRequestSyncSession, context, pullRequest))
 			.flatMap(Optional::stream)
 			.toList();
 
@@ -288,12 +288,12 @@ public class TeamspaceService {
 
 	private Optional<GithubPullRequestInfo> getPullRequestDetail(
 		GithubPullRequestSyncSession pullRequestSyncSession,
-		ProjectGroupGithubRepository repository,
+		GithubPullRequestSyncContext context,
 		GithubPullRequestSummary pullRequest
 	) {
 		return pullRequestSyncSession.getPullRequest(
-			repository.getOwner(),
-			repository.getRepoName(),
+			context.owner(),
+			context.repoName(),
 			pullRequest.pullNumber()
 		);
 	}

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -2,6 +2,7 @@ package team.po.feature.teamspace.service;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -268,6 +269,7 @@ public class TeamspaceService {
 		List<GithubPullRequestInfo> newMergedPullRequests = mergedPullRequestSummaries.stream()
 			.filter(pullRequest -> !existingGithubPrIds.contains(pullRequest.githubPullRequestId()))
 			.map(pullRequest -> getPullRequestDetail(installationId, repository, pullRequest))
+			.flatMap(Optional::stream)
 			.toList();
 
 		teamspacePersistenceTxService.persistGithubPullRequestContributions(
@@ -282,7 +284,7 @@ public class TeamspaceService {
 		syncGithubPullRequestContributions(projectGroupId, githubRepositoryId);
 	}
 
-	private GithubPullRequestInfo getPullRequestDetail(
+	private Optional<GithubPullRequestInfo> getPullRequestDetail(
 		Long installationId,
 		ProjectGroupGithubRepository repository,
 		GithubPullRequestSummary pullRequest

--- a/src/main/java/team/po/feature/user/oauth/GithubOAuthAuthorizationRequestRepository.java
+++ b/src/main/java/team/po/feature/user/oauth/GithubOAuthAuthorizationRequestRepository.java
@@ -9,8 +9,10 @@ import org.springframework.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import team.po.feature.user.service.GithubOAuthService;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GithubOAuthAuthorizationRequestRepository
@@ -33,6 +35,7 @@ public class GithubOAuthAuthorizationRequestRepository
 		HttpServletResponse response
 	) {
 		if (authorizationRequest != null) {
+			log.info("GitHub OAuth authorization request scopes: {}", authorizationRequest.getScopes());
 			String linkCode = request.getParameter(LINK_CODE_PARAMETER);
 			if (StringUtils.hasText(linkCode)) {
 				githubOAuthService.bindGithubLinkState(authorizationRequest.getState(), linkCode);

--- a/src/main/resources/db/migration/V17__create_github_pull_request_contribution_table.sql
+++ b/src/main/resources/db/migration/V17__create_github_pull_request_contribution_table.sql
@@ -1,0 +1,49 @@
+CREATE TABLE github_pull_request_contribution
+(
+    id                    BIGINT AUTO_INCREMENT PRIMARY KEY,
+    project_group_id      BIGINT        NOT NULL,
+    github_repository_id  BIGINT        NOT NULL,
+    github_pr_id          BIGINT        NOT NULL,
+    pr_number             BIGINT        NOT NULL,
+    title                 VARCHAR(512)  NOT NULL,
+    author_github_user_id BIGINT        NOT NULL,
+    author_github_username VARCHAR(255) NOT NULL,
+    state                 VARCHAR(30)   NOT NULL,
+    merged                BOOLEAN       NOT NULL DEFAULT FALSE,
+    merged_at             TIMESTAMP(6)  NULL,
+    additions             INT           NOT NULL DEFAULT 0,
+    deletions             INT           NOT NULL DEFAULT 0,
+    changed_files         INT           NOT NULL DEFAULT 0,
+    linked_issue_count    INT           NOT NULL DEFAULT 0,
+    html_url              VARCHAR(2048) NOT NULL,
+    created_at            TIMESTAMP(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at            TIMESTAMP(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    synced_at             TIMESTAMP(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+
+    CONSTRAINT fk_github_pull_request_contribution_project_group
+        FOREIGN KEY (project_group_id) REFERENCES project_group (id),
+
+    CONSTRAINT uq_github_pull_request_contribution_repository_pr
+        UNIQUE (project_group_id, github_repository_id, github_pr_id),
+
+    CONSTRAINT ck_github_pull_request_contribution_additions
+        CHECK (additions >= 0),
+
+    CONSTRAINT ck_github_pull_request_contribution_deletions
+        CHECK (deletions >= 0),
+
+    CONSTRAINT ck_github_pull_request_contribution_changed_files
+        CHECK (changed_files >= 0),
+
+    CONSTRAINT ck_github_pull_request_contribution_linked_issue_count
+        CHECK (linked_issue_count >= 0)
+);
+
+CREATE INDEX idx_github_pull_request_contribution_project_group_repository
+    ON github_pull_request_contribution (project_group_id, github_repository_id);
+
+CREATE INDEX idx_github_pull_request_contribution_author
+    ON github_pull_request_contribution (author_github_user_id);
+
+CREATE INDEX idx_github_pull_request_contribution_merged_at
+    ON github_pull_request_contribution (merged_at);

--- a/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
+++ b/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
@@ -203,6 +203,7 @@ class TeamspaceControllerTest {
 				"backend",
 				"student-team-org/backend",
 				List.of(new GetGithubRepositoryContributionResponse.ContributorResponse(
+					1L,
 					501L,
 					"dev-a",
 					3L,
@@ -219,6 +220,7 @@ class TeamspaceControllerTest {
 			.andExpect(jsonPath("$.githubRepositoryId").value(100))
 			.andExpect(jsonPath("$.repoName").value("backend"))
 			.andExpect(jsonPath("$.fullName").value("student-team-org/backend"))
+			.andExpect(jsonPath("$.contributors[0].userId").value(1))
 			.andExpect(jsonPath("$.contributors[0].githubUserId").value(501))
 			.andExpect(jsonPath("$.contributors[0].githubUsername").value("dev-a"))
 			.andExpect(jsonPath("$.contributors[0].mergedPrCount").value(3))

--- a/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
+++ b/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
@@ -33,6 +33,7 @@ import team.po.feature.teamspace.dto.CompleteGithubAppInstallationRequest;
 import team.po.feature.teamspace.dto.CreateGithubAppInstallationUrlResponse;
 import team.po.feature.teamspace.dto.GetAvailableGithubRepositoryList;
 import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
+import team.po.feature.teamspace.dto.GetGithubRepositoryContributionResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.service.TeamspaceService;
@@ -192,6 +193,42 @@ class TeamspaceControllerTest {
 			10L,
 			new SetGithubRepositoryListRequest(List.of())
 		);
+	}
+
+	@Test
+	void getGithubRepositoryContributions_returnsOk() throws Exception {
+		when(teamspaceService.getGithubRepositoryContributions(mockUser, 10L, 100L))
+			.thenReturn(new GetGithubRepositoryContributionResponse(
+				100L,
+				"backend",
+				"student-team-org/backend",
+				List.of(new GetGithubRepositoryContributionResponse.ContributorResponse(
+					501L,
+					"dev-a",
+					3L,
+					2L,
+					120L,
+					15L,
+					8L,
+					40L
+				))
+			));
+
+		mockMvc.perform(get("/api/team-space/10/github/repositories/100/contributions"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.githubRepositoryId").value(100))
+			.andExpect(jsonPath("$.repoName").value("backend"))
+			.andExpect(jsonPath("$.fullName").value("student-team-org/backend"))
+			.andExpect(jsonPath("$.contributors[0].githubUserId").value(501))
+			.andExpect(jsonPath("$.contributors[0].githubUsername").value("dev-a"))
+			.andExpect(jsonPath("$.contributors[0].mergedPrCount").value(3))
+			.andExpect(jsonPath("$.contributors[0].linkedIssueCount").value(2))
+			.andExpect(jsonPath("$.contributors[0].additions").value(120))
+			.andExpect(jsonPath("$.contributors[0].deletions").value(15))
+			.andExpect(jsonPath("$.contributors[0].changedFiles").value(8))
+			.andExpect(jsonPath("$.contributors[0].contributionScore").value(40));
+
+		verify(teamspaceService).getGithubRepositoryContributions(mockUser, 10L, 100L);
 	}
 
 	@Test

--- a/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
+++ b/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
@@ -193,4 +193,14 @@ class TeamspaceControllerTest {
 			new SetGithubRepositoryListRequest(List.of())
 		);
 	}
+
+	@Test
+	void syncGithubPullRequestContributions_returnsOk() throws Exception {
+		mockMvc.perform(post(
+				"/api/team-space/10/github/repositories/100/pull-request-contributions/sync"
+			))
+			.andExpect(status().isOk());
+
+		verify(teamspaceService).syncGithubPullRequestContributions(mockUser, 10L, 100L);
+	}
 }

--- a/src/test/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepositoryTest.java
+++ b/src/test/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepositoryTest.java
@@ -1,0 +1,198 @@
+package team.po.feature.teamspace.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.EntityManager;
+import team.po.feature.teamspace.repository.GithubPullRequestContributionRepository.GithubRepositoryContributionSummary;
+
+@DataJpaTest
+@ActiveProfiles("h2")
+class GithubPullRequestContributionRepositoryTest {
+
+	@Autowired
+	private GithubPullRequestContributionRepository repository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void findContributionSummaries_returnsOnlyActiveGithubAccountsInProjectGroupMembers() {
+		insertUser(1L, "member-a@example.com", "member-a");
+		insertUser(2L, "member-b@example.com", "member-b");
+		insertUser(3L, "outsider@example.com", "outsider");
+		insertUser(4L, "deleted-github@example.com", "deleted-github");
+		insertProjectGroup(10L);
+		insertProjectGroupMember(1L, 10L);
+		insertProjectGroupMember(2L, 10L);
+		insertProjectGroupMember(4L, 10L);
+		insertGithubAccount(1L, 1L, 501L, "dev-a", null);
+		insertGithubAccount(2L, 2L, 502L, "dev-b", null);
+		insertGithubAccount(3L, 3L, 503L, "outsider", null);
+		insertGithubAccount(4L, 4L, 504L, "deleted-dev", Instant.parse("2026-05-03T00:00:00Z"));
+		insertContribution(1L, 10L, 100L, 1001L, 501L, "dev-a", true, 2, 100, 10, 4);
+		insertContribution(2L, 10L, 100L, 1002L, 501L, "dev-a-old", true, 1, 20, 5, 2);
+		insertContribution(3L, 10L, 100L, 1003L, 502L, "dev-b", true, 0, 70, 7, 3);
+		insertContribution(4L, 10L, 100L, 1004L, 503L, "outsider", true, 10, 999, 999, 99);
+		insertContribution(5L, 10L, 100L, 1005L, 504L, "deleted-dev", true, 10, 999, 999, 99);
+		insertContribution(6L, 10L, 100L, 1006L, 501L, "dev-a", false, 10, 999, 999, 99);
+		insertContribution(7L, 10L, 200L, 2001L, 501L, "dev-a", true, 10, 999, 999, 99);
+		entityManager.flush();
+		entityManager.clear();
+
+		List<GithubRepositoryContributionSummary> summaries = repository.findContributionSummaries(10L, 100L);
+
+		assertThat(summaries).hasSize(2);
+		GithubRepositoryContributionSummary first = summaries.get(0);
+		assertThat(first.getUserId()).isEqualTo(1L);
+		assertThat(first.getGithubUserId()).isEqualTo(501L);
+		assertThat(first.getGithubUsername()).isEqualTo("dev-a");
+		assertThat(first.getMergedPrCount()).isEqualTo(2L);
+		assertThat(first.getLinkedIssueCount()).isEqualTo(3L);
+		assertThat(first.getAdditions()).isEqualTo(120L);
+		assertThat(first.getDeletions()).isEqualTo(15L);
+		assertThat(first.getChangedFiles()).isEqualTo(6L);
+
+		GithubRepositoryContributionSummary second = summaries.get(1);
+		assertThat(second.getUserId()).isEqualTo(2L);
+		assertThat(second.getGithubUserId()).isEqualTo(502L);
+		assertThat(second.getGithubUsername()).isEqualTo("dev-b");
+		assertThat(second.getMergedPrCount()).isEqualTo(1L);
+		assertThat(second.getLinkedIssueCount()).isZero();
+		assertThat(second.getAdditions()).isEqualTo(70L);
+		assertThat(second.getDeletions()).isEqualTo(7L);
+		assertThat(second.getChangedFiles()).isEqualTo(3L);
+	}
+
+	private void insertUser(Long id, String email, String nickname) {
+		entityManager.createNativeQuery("""
+			INSERT INTO users (
+				id, email, nickname, temperature, level, is_github_login, created_at
+			) VALUES (
+				:id, :email, :nickname, 50, 1, false, CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("email", email)
+			.setParameter("nickname", nickname)
+			.executeUpdate();
+	}
+
+	private void insertProjectGroup(Long id) {
+		entityManager.createNativeQuery("""
+			INSERT INTO project_group (
+				id, project_name, project_title, status, created_at
+			) VALUES (
+				:id, 'TeamPo', 'TeamPo', 'ACTIVE', CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.executeUpdate();
+	}
+
+	private void insertProjectGroupMember(Long userId, Long projectGroupId) {
+		entityManager.createNativeQuery("""
+			INSERT INTO project_group_member (
+				user_id, project_group_id, role, group_role, is_admin, created_at
+			) VALUES (
+				:userId, :projectGroupId, 'BACKEND', 'MEMBER', false, CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("userId", userId)
+			.setParameter("projectGroupId", projectGroupId)
+			.executeUpdate();
+	}
+
+	private void insertGithubAccount(Long id, Long userId, Long githubUserId, String githubUsername, Instant deletedAt) {
+		entityManager.createNativeQuery("""
+			INSERT INTO github_account (
+				id, user_id, github_user_id, github_username, connected_at, created_at, deleted_at
+			) VALUES (
+				:id, :userId, :githubUserId, :githubUsername, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, :deletedAt
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("userId", userId)
+			.setParameter("githubUserId", githubUserId)
+			.setParameter("githubUsername", githubUsername)
+			.setParameter("deletedAt", deletedAt)
+			.executeUpdate();
+	}
+
+	private void insertContribution(
+		Long id,
+		Long projectGroupId,
+		Long githubRepositoryId,
+		Long githubPrId,
+		Long authorGithubUserId,
+		String authorGithubUsername,
+		boolean merged,
+		int linkedIssueCount,
+		int additions,
+		int deletions,
+		int changedFiles
+	) {
+		entityManager.createNativeQuery("""
+			INSERT INTO github_pull_request_contribution (
+				id,
+				project_group_id,
+				github_repository_id,
+				github_pr_id,
+				pr_number,
+				title,
+				author_github_user_id,
+				author_github_username,
+				state,
+				merged,
+				merged_at,
+				additions,
+				deletions,
+				changed_files,
+				linked_issue_count,
+				html_url,
+				created_at,
+				updated_at,
+				synced_at
+			) VALUES (
+				:id,
+				:projectGroupId,
+				:githubRepositoryId,
+				:githubPrId,
+				:id,
+				'PR title',
+				:authorGithubUserId,
+				:authorGithubUsername,
+				'closed',
+				:merged,
+				CURRENT_TIMESTAMP,
+				:additions,
+				:deletions,
+				:changedFiles,
+				:linkedIssueCount,
+				'https://github.com/student-team-org/backend/pull/1',
+				CURRENT_TIMESTAMP,
+				CURRENT_TIMESTAMP,
+				CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("projectGroupId", projectGroupId)
+			.setParameter("githubRepositoryId", githubRepositoryId)
+			.setParameter("githubPrId", githubPrId)
+			.setParameter("authorGithubUserId", authorGithubUserId)
+			.setParameter("authorGithubUsername", authorGithubUsername)
+			.setParameter("merged", merged)
+			.setParameter("additions", additions)
+			.setParameter("deletions", deletions)
+			.setParameter("changedFiles", changedFiles)
+			.setParameter("linkedIssueCount", linkedIssueCount)
+			.executeUpdate();
+	}
+}

--- a/src/test/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepositoryTest.java
+++ b/src/test/java/team/po/feature/teamspace/repository/GithubPullRequestContributionRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +70,25 @@ class GithubPullRequestContributionRepositoryTest {
 		assertThat(second.getAdditions()).isEqualTo(70L);
 		assertThat(second.getDeletions()).isEqualTo(7L);
 		assertThat(second.getChangedFiles()).isEqualTo(3L);
+	}
+
+	@Test
+	void findExistingGithubPrIds_returnsStoredPullRequestIdsInRepository() {
+		insertUser(1L, "member-a@example.com", "member-a");
+		insertProjectGroup(10L);
+		insertContribution(1L, 10L, 100L, 1001L, 501L, "dev-a", true, 0, 10, 1, 1);
+		insertContribution(2L, 10L, 100L, 1002L, 501L, "dev-a", true, 0, 10, 1, 1);
+		insertContribution(3L, 10L, 200L, 2001L, 501L, "dev-a", true, 0, 10, 1, 1);
+		entityManager.flush();
+		entityManager.clear();
+
+		Set<Long> existingGithubPrIds = repository.findExistingGithubPrIds(
+			10L,
+			100L,
+			Set.of(1001L, 1002L, 9999L)
+		);
+
+		assertThat(existingGithubPrIds).containsExactlyInAnyOrder(1001L, 1002L);
 	}
 
 	private void insertUser(Long id, String email, String nickname) {

--- a/src/test/java/team/po/feature/teamspace/repository/ProjectGroupGithubRepositoryRepositoryTest.java
+++ b/src/test/java/team/po/feature/teamspace/repository/ProjectGroupGithubRepositoryRepositoryTest.java
@@ -1,0 +1,143 @@
+package team.po.feature.teamspace.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.EntityManager;
+import team.po.feature.teamspace.dto.GithubPullRequestSyncContext;
+
+@DataJpaTest
+@ActiveProfiles("h2")
+class ProjectGroupGithubRepositoryRepositoryTest {
+
+	@Autowired
+	private ProjectGroupGithubRepositoryRepository repository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void findGithubPullRequestSyncContext_returnsInstallationAndRepositoryFields() {
+		insertProjectGroup(10L);
+		insertGithubInstallation(5L, 12345L);
+		insertGithubRepository(1L, 10L, 5L, 100L, "student-team-org", "backend", null);
+		entityManager.flush();
+		entityManager.clear();
+
+		GithubPullRequestSyncContext context = repository.findGithubPullRequestSyncContext(10L, 100L)
+			.orElseThrow();
+
+		assertThat(context.installationId()).isEqualTo(12345L);
+		assertThat(context.owner()).isEqualTo("student-team-org");
+		assertThat(context.repoName()).isEqualTo("backend");
+	}
+
+	@Test
+	void findGithubPullRequestSyncContext_returnsEmpty_whenRepositoryIsDeleted() {
+		insertProjectGroup(10L);
+		insertGithubInstallation(5L, 12345L);
+		insertGithubRepository(
+			1L,
+			10L,
+			5L,
+			100L,
+			"student-team-org",
+			"backend",
+			Instant.parse("2026-05-01T00:00:00Z")
+		);
+		entityManager.flush();
+		entityManager.clear();
+
+		assertThat(repository.findGithubPullRequestSyncContext(10L, 100L)).isEmpty();
+	}
+
+	private void insertProjectGroup(Long id) {
+		entityManager.createNativeQuery("""
+			INSERT INTO project_group (
+				id, project_name, project_title, status, created_at
+			) VALUES (
+				:id, 'TeamPo', 'TeamPo', 'ACTIVE', CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.executeUpdate();
+	}
+
+	private void insertGithubInstallation(Long id, Long installationId) {
+		entityManager.createNativeQuery("""
+			INSERT INTO github_installation (
+				id,
+				installation_id,
+				account_id,
+				account_login,
+				account_type,
+				created_at,
+				updated_at
+			) VALUES (
+				:id,
+				:installationId,
+				98765,
+				'student-team-org',
+				'Organization',
+				CURRENT_TIMESTAMP,
+				CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("installationId", installationId)
+			.executeUpdate();
+	}
+
+	private void insertGithubRepository(
+		Long id,
+		Long projectGroupId,
+		Long githubInstallationId,
+		Long githubRepositoryId,
+		String owner,
+		String repoName,
+		Instant deletedAt
+	) {
+		entityManager.createNativeQuery("""
+			INSERT INTO project_group_github_repository (
+				id,
+				project_group_id,
+				github_installation_id,
+				github_repository_id,
+				owner,
+				repo_name,
+				full_name,
+				default_branch,
+				is_private,
+				created_at,
+				deleted_at
+			) VALUES (
+				:id,
+				:projectGroupId,
+				:githubInstallationId,
+				:githubRepositoryId,
+				:owner,
+				:repoName,
+				:fullName,
+				'main',
+				true,
+				CURRENT_TIMESTAMP,
+				:deletedAt
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("projectGroupId", projectGroupId)
+			.setParameter("githubInstallationId", githubInstallationId)
+			.setParameter("githubRepositoryId", githubRepositoryId)
+			.setParameter("owner", owner)
+			.setParameter("repoName", repoName)
+			.setParameter("fullName", owner + "/" + repoName)
+			.setParameter("deletedAt", deletedAt)
+			.executeUpdate();
+	}
+}

--- a/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
@@ -19,6 +19,7 @@ import org.springframework.web.client.RestClient;
 import team.po.config.GithubAppProperties;
 import team.po.exception.ApplicationException;
 import team.po.exception.ErrorCode;
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
 import team.po.feature.teamspace.provider.GithubAppJwtProvider;
 import team.po.feature.teamspace.service.GithubAppClient.GithubAppInstallationInfo;
 
@@ -223,6 +224,15 @@ class GithubAppClientTest {
 			writeResponse(exchange, 200, """
 				[
 				  {
+				    "id": 999,
+				    "number": 9,
+				    "title": "Old PR from deleted user",
+				    "state": "closed",
+				    "merged_at": "2026-04-01T10:15:30Z",
+				    "html_url": "https://github.com/student-team-org/backend/pull/9",
+				    "user": null
+				  },
+				  {
 				    "id": 1001,
 				    "number": 10,
 				    "title": "Add contribution sync",
@@ -299,13 +309,51 @@ class GithubAppClientTest {
 
 			var pullRequest = client.getPullRequest(12345L, "student-team-org", "backend", 10L);
 
-			assertThat(pullRequest.githubPullRequestId()).isEqualTo(1001L);
-			assertThat(pullRequest.pullNumber()).isEqualTo(10L);
-			assertThat(pullRequest.authorGithubUserId()).isEqualTo(501L);
-			assertThat(pullRequest.additions()).isEqualTo(120);
-			assertThat(pullRequest.deletions()).isEqualTo(15);
-			assertThat(pullRequest.changedFiles()).isEqualTo(8);
-			assertThat(pullRequest.htmlUrl()).isEqualTo("https://github.com/student-team-org/backend/pull/10");
+			assertThat(pullRequest).isPresent();
+			GithubPullRequestInfo pullRequestInfo = pullRequest.orElseThrow();
+			assertThat(pullRequestInfo.githubPullRequestId()).isEqualTo(1001L);
+			assertThat(pullRequestInfo.pullNumber()).isEqualTo(10L);
+			assertThat(pullRequestInfo.authorGithubUserId()).isEqualTo(501L);
+			assertThat(pullRequestInfo.additions()).isEqualTo(120);
+			assertThat(pullRequestInfo.deletions()).isEqualTo(15);
+			assertThat(pullRequestInfo.changedFiles()).isEqualTo(8);
+			assertThat(pullRequestInfo.htmlUrl()).isEqualTo("https://github.com/student-team-org/backend/pull/10");
+		} finally {
+			server.stop(0);
+		}
+	}
+
+	@Test
+	void getPullRequest_returnsEmpty_whenPullRequestUserIsMissing() throws Exception {
+		GithubAppJwtProvider jwtProvider = Mockito.mock(GithubAppJwtProvider.class);
+		when(jwtProvider.generateJwt()).thenReturn("github-app-jwt");
+
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/app/installations/12345/access_tokens", exchange -> writeResponse(exchange, 201, """
+			{
+			  "token": "github-installation-token"
+			}
+			"""));
+		server.createContext("/repos/student-team-org/backend/pulls/10", exchange -> writeResponse(exchange, 200, """
+			{
+			  "id": 1001,
+			  "number": 10,
+			  "title": "Old PR from deleted user",
+			  "state": "closed",
+			  "merged_at": "2026-05-01T10:15:30Z",
+			  "additions": 120,
+			  "deletions": 15,
+			  "changed_files": 8,
+			  "html_url": "https://github.com/student-team-org/backend/pull/10",
+			  "user": null
+			}
+			"""));
+		server.start();
+
+		try {
+			GithubAppClient client = githubAppClient(server, jwtProvider);
+
+			assertThat(client.getPullRequest(12345L, "student-team-org", "backend", 10L)).isEmpty();
 		} finally {
 			server.stop(0);
 		}

--- a/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
@@ -200,6 +200,118 @@ class GithubAppClientTest {
 	}
 
 	@Test
+	void getClosedPullRequests_returnsClosedPullRequests() throws Exception {
+		GithubAppJwtProvider jwtProvider = Mockito.mock(GithubAppJwtProvider.class);
+		when(jwtProvider.generateJwt()).thenReturn("github-app-jwt");
+
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/app/installations/12345/access_tokens", exchange -> {
+			assertThat(exchange.getRequestMethod()).isEqualTo("POST");
+			assertThat(exchange.getRequestHeaders().getFirst("Authorization")).isEqualTo("Bearer github-app-jwt");
+			writeResponse(exchange, 201, """
+				{
+				  "token": "github-installation-token"
+				}
+				""");
+		});
+		server.createContext("/repos/student-team-org/backend/pulls", exchange -> {
+			assertThat(exchange.getRequestHeaders().getFirst("Authorization"))
+				.isEqualTo("Bearer github-installation-token");
+			assertThat(exchange.getRequestHeaders().getFirst("Accept")).isEqualTo("application/vnd.github+json");
+			assertThat(exchange.getRequestHeaders().getFirst("X-GitHub-Api-Version")).isEqualTo("2022-11-28");
+			assertThat(exchange.getRequestURI().getQuery()).contains("state=closed", "per_page=100", "page=1");
+			writeResponse(exchange, 200, """
+				[
+				  {
+				    "id": 1001,
+				    "number": 10,
+				    "title": "Add contribution sync",
+				    "state": "closed",
+				    "merged_at": "2026-05-01T10:15:30Z",
+				    "html_url": "https://github.com/student-team-org/backend/pull/10",
+				    "user": {
+				      "id": 501,
+				      "login": "dev-a"
+				    }
+				  }
+				]
+				""");
+		});
+		server.start();
+
+		try {
+			GithubAppClient client = githubAppClient(server, jwtProvider);
+
+			var pullRequests = client.getClosedPullRequests(12345L, "student-team-org", "backend");
+
+			assertThat(pullRequests).hasSize(1);
+			assertThat(pullRequests.get(0).githubPullRequestId()).isEqualTo(1001L);
+			assertThat(pullRequests.get(0).pullNumber()).isEqualTo(10L);
+			assertThat(pullRequests.get(0).title()).isEqualTo("Add contribution sync");
+			assertThat(pullRequests.get(0).authorGithubUserId()).isEqualTo(501L);
+			assertThat(pullRequests.get(0).authorGithubUsername()).isEqualTo("dev-a");
+			assertThat(pullRequests.get(0).state()).isEqualTo("closed");
+			assertThat(pullRequests.get(0).htmlUrl())
+				.isEqualTo("https://github.com/student-team-org/backend/pull/10");
+		} finally {
+			server.stop(0);
+		}
+	}
+
+	@Test
+	void getPullRequest_returnsPullRequestDetail() throws Exception {
+		GithubAppJwtProvider jwtProvider = Mockito.mock(GithubAppJwtProvider.class);
+		when(jwtProvider.generateJwt()).thenReturn("github-app-jwt");
+
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/app/installations/12345/access_tokens", exchange -> writeResponse(exchange, 201, """
+			{
+			  "token": "github-installation-token"
+			}
+			"""));
+		server.createContext("/repos/student-team-org/backend/pulls/10", exchange -> {
+			assertThat(exchange.getRequestHeaders().getFirst("Authorization"))
+				.isEqualTo("Bearer github-installation-token");
+			assertThat(exchange.getRequestHeaders().getFirst("Accept")).isEqualTo("application/vnd.github+json");
+			assertThat(exchange.getRequestHeaders().getFirst("X-GitHub-Api-Version")).isEqualTo("2022-11-28");
+			writeResponse(exchange, 200, """
+				{
+				  "id": 1001,
+				  "number": 10,
+				  "title": "Add contribution sync",
+				  "state": "closed",
+				  "merged_at": "2026-05-01T10:15:30Z",
+				  "additions": 120,
+				  "deletions": 15,
+				  "changed_files": 8,
+				  "html_url": "https://github.com/student-team-org/backend/pull/10",
+				  "user": {
+				    "id": 501,
+				    "login": "dev-a"
+				  }
+				}
+				""");
+		});
+		server.start();
+
+		try {
+			GithubAppClient client = githubAppClient(server, jwtProvider);
+
+			var pullRequest = client.getPullRequest(12345L, "student-team-org", "backend", 10L);
+
+			assertThat(pullRequest.githubPullRequestId()).isEqualTo(1001L);
+			assertThat(pullRequest.pullNumber()).isEqualTo(10L);
+			assertThat(pullRequest.authorGithubUserId()).isEqualTo(501L);
+			assertThat(pullRequest.additions()).isEqualTo(120);
+			assertThat(pullRequest.deletions()).isEqualTo(15);
+			assertThat(pullRequest.changedFiles()).isEqualTo(8);
+			assertThat(pullRequest.htmlUrl()).isEqualTo("https://github.com/student-team-org/backend/pull/10");
+		} finally {
+			server.stop(0);
+		}
+	}
+
+	@Test
 	void validateOrganizationAdmin_throwsForbiddenWhenMembershipIsNotAdmin() throws Exception {
 		GithubAppJwtProvider jwtProvider = Mockito.mock(GithubAppJwtProvider.class);
 

--- a/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
@@ -320,6 +321,69 @@ class GithubAppClientTest {
 			assertThat(pullRequestInfo.changedFiles()).isEqualTo(8);
 			assertThat(pullRequestInfo.linkedIssueCount()).isEqualTo(4);
 			assertThat(pullRequestInfo.htmlUrl()).isEqualTo("https://github.com/student-team-org/backend/pull/10");
+		} finally {
+			server.stop(0);
+		}
+	}
+
+	@Test
+	void pullRequestSyncSession_reusesInstallationAccessToken() throws Exception {
+		GithubAppJwtProvider jwtProvider = Mockito.mock(GithubAppJwtProvider.class);
+		when(jwtProvider.generateJwt()).thenReturn("github-app-jwt");
+		AtomicInteger accessTokenRequestCount = new AtomicInteger();
+
+		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/app/installations/12345/access_tokens", exchange -> {
+			accessTokenRequestCount.incrementAndGet();
+			writeResponse(exchange, 201, """
+				{
+				  "token": "github-installation-token"
+				}
+				""");
+		});
+		server.createContext("/repos/student-team-org/backend/pulls", exchange -> writeResponse(exchange, 200, """
+			[
+			  {
+			    "id": 1001,
+			    "number": 10,
+			    "title": "Add contribution sync",
+			    "state": "closed",
+			    "merged_at": "2026-05-01T10:15:30Z",
+			    "html_url": "https://github.com/student-team-org/backend/pull/10",
+			    "user": {
+			      "id": 501,
+			      "login": "dev-a"
+			    }
+			  }
+			]
+			"""));
+		server.createContext("/repos/student-team-org/backend/pulls/10", exchange -> writeResponse(exchange, 200, """
+			{
+			  "id": 1001,
+			  "number": 10,
+			  "title": "Add contribution sync",
+			  "state": "closed",
+			  "merged_at": "2026-05-01T10:15:30Z",
+			  "additions": 120,
+			  "deletions": 15,
+			  "changed_files": 8,
+			  "body": "Closes #10",
+			  "html_url": "https://github.com/student-team-org/backend/pull/10",
+			  "user": {
+			    "id": 501,
+			    "login": "dev-a"
+			  }
+			}
+			"""));
+		server.start();
+
+		try {
+			GithubAppClient client = githubAppClient(server, jwtProvider);
+			GithubPullRequestSyncSession session = client.createPullRequestSyncSession(12345L);
+
+			assertThat(session.getClosedPullRequests("student-team-org", "backend")).hasSize(1);
+			assertThat(session.getPullRequest("student-team-org", "backend", 10L)).isPresent();
+			assertThat(accessTokenRequestCount).hasValue(1);
 		} finally {
 			server.stop(0);
 		}

--- a/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/GithubAppClientTest.java
@@ -294,6 +294,7 @@ class GithubAppClientTest {
 				  "additions": 120,
 				  "deletions": 15,
 				  "changed_files": 8,
+				  "body": "Closes #10\\nFixes #11 and #12\\nResolves student-team-org/frontend#13\\nCloses #10",
 				  "html_url": "https://github.com/student-team-org/backend/pull/10",
 				  "user": {
 				    "id": 501,
@@ -317,6 +318,7 @@ class GithubAppClientTest {
 			assertThat(pullRequestInfo.additions()).isEqualTo(120);
 			assertThat(pullRequestInfo.deletions()).isEqualTo(15);
 			assertThat(pullRequestInfo.changedFiles()).isEqualTo(8);
+			assertThat(pullRequestInfo.linkedIssueCount()).isEqualTo(4);
 			assertThat(pullRequestInfo.htmlUrl()).isEqualTo("https://github.com/student-team-org/backend/pull/10");
 		} finally {
 			server.stop(0);

--- a/src/test/java/team/po/feature/teamspace/service/TeamspacePersistenceTxServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspacePersistenceTxServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,10 +27,13 @@ import team.po.feature.projectgroup.domain.ProjectGroupStatus;
 import team.po.feature.projectgroup.repository.ProjectGroupMemberRepository;
 import team.po.feature.projectgroup.repository.ProjectGroupRepository;
 import team.po.feature.teamspace.domain.GithubInstallation;
+import team.po.feature.teamspace.domain.GithubPullRequestContribution;
 import team.po.feature.teamspace.domain.ProjectGroupGithubInstallation;
 import team.po.feature.teamspace.domain.ProjectGroupGithubRepository;
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
+import team.po.feature.teamspace.repository.GithubPullRequestContributionRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubInstallationRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubRepositoryRepository;
 import team.po.feature.user.domain.Users;
@@ -52,6 +56,9 @@ class TeamspacePersistenceTxServiceTest {
 	@Mock
 	private GithubInstallationRepository githubInstallationRepository;
 
+	@Mock
+	private GithubPullRequestContributionRepository githubPullRequestContributionRepository;
+
 	private TeamspacePersistenceTxService service;
 
 	@BeforeEach
@@ -61,7 +68,8 @@ class TeamspacePersistenceTxServiceTest {
 			projectGroupRepository,
 			projectGroupGithubInstallationRepository,
 			projectGroupGithubRepositoryRepository,
-			githubInstallationRepository
+			githubInstallationRepository,
+			githubPullRequestContributionRepository
 		);
 	}
 
@@ -260,12 +268,140 @@ class TeamspacePersistenceTxServiceTest {
 		verify(projectGroupGithubRepositoryRepository, never()).saveAll(any());
 	}
 
+	@Test
+	void persistGithubPullRequestContributions_updatesExistingAndSavesNewContributions() {
+		ProjectGroup projectGroup = projectGroup();
+		GithubPullRequestContribution existingContribution = GithubPullRequestContribution.builder()
+			.projectGroup(projectGroup)
+			.githubRepositoryId(100L)
+			.githubPrId(1001L)
+			.prNumber(10L)
+			.title("Old title")
+			.authorGithubUserId(501L)
+			.authorGithubUsername("old-dev")
+			.state("open")
+			.merged(false)
+			.mergedAt(null)
+			.additions(1)
+			.deletions(2)
+			.changedFiles(1)
+			.linkedIssueCount(0)
+			.htmlUrl("https://github.com/student-team-org/backend/pull/10")
+			.syncedAt(Instant.parse("2026-05-01T00:00:00Z"))
+			.build();
+		ReflectionTestUtils.setField(existingContribution, "id", 1L);
+		Instant mergedAt = Instant.parse("2026-05-02T10:00:00Z");
+		GithubPullRequestInfo existingPullRequest = new GithubPullRequestInfo(
+			1001L,
+			10L,
+			"Add contribution sync",
+			501L,
+			"dev-a",
+			"closed",
+			mergedAt,
+			120,
+			15,
+			8,
+			"https://github.com/student-team-org/backend/pull/10"
+		);
+		GithubPullRequestInfo newPullRequest = new GithubPullRequestInfo(
+			1002L,
+			11L,
+			"Add contribution query",
+			502L,
+			"dev-b",
+			"closed",
+			Instant.parse("2026-05-03T10:00:00Z"),
+			80,
+			5,
+			4,
+			"https://github.com/student-team-org/backend/pull/11"
+		);
+		when(projectGroupRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(projectGroup));
+		when(githubPullRequestContributionRepository.findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(
+			10L,
+			100L,
+			1001L
+		)).thenReturn(Optional.of(existingContribution));
+		when(githubPullRequestContributionRepository.findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(
+			10L,
+			100L,
+			1002L
+		)).thenReturn(Optional.empty());
+
+		service.persistGithubPullRequestContributions(
+			10L,
+			100L,
+			List.of(existingPullRequest, newPullRequest)
+		);
+
+		verify(projectGroupRepository).findByIdForUpdate(10L);
+		assertThat(existingContribution.getTitle()).isEqualTo("Add contribution sync");
+		assertThat(existingContribution.getAuthorGithubUsername()).isEqualTo("dev-a");
+		assertThat(existingContribution.getState()).isEqualTo("closed");
+		assertThat(existingContribution.isMerged()).isTrue();
+		assertThat(existingContribution.getMergedAt()).isEqualTo(mergedAt);
+		assertThat(existingContribution.getAdditions()).isEqualTo(120);
+		assertThat(existingContribution.getDeletions()).isEqualTo(15);
+		assertThat(existingContribution.getChangedFiles()).isEqualTo(8);
+		assertThat(existingContribution.getSyncedAt()).isNotNull();
+
+		ArgumentCaptor<List<GithubPullRequestContribution>> contributionCaptor = ArgumentCaptor.forClass(List.class);
+		verify(githubPullRequestContributionRepository).saveAll(contributionCaptor.capture());
+		assertThat(contributionCaptor.getValue()).hasSize(1);
+		GithubPullRequestContribution newContribution = contributionCaptor.getValue().get(0);
+		assertThat(newContribution.getGithubRepositoryId()).isEqualTo(100L);
+		assertThat(newContribution.getGithubPrId()).isEqualTo(1002L);
+		assertThat(newContribution.getPrNumber()).isEqualTo(11L);
+		assertThat(newContribution.getTitle()).isEqualTo("Add contribution query");
+		assertThat(newContribution.getAuthorGithubUserId()).isEqualTo(502L);
+		assertThat(newContribution.getAuthorGithubUsername()).isEqualTo("dev-b");
+		assertThat(newContribution.isMerged()).isTrue();
+		assertThat(newContribution.getAdditions()).isEqualTo(80);
+		assertThat(newContribution.getDeletions()).isEqualTo(5);
+		assertThat(newContribution.getChangedFiles()).isEqualTo(4);
+		assertThat(newContribution.getLinkedIssueCount()).isZero();
+		assertThat(newContribution.getSyncedAt()).isNotNull();
+	}
+
+	@Test
+	void persistGithubPullRequestContributions_throwsNotFound_whenProjectGroupDoesNotExist() {
+		when(projectGroupRepository.findByIdForUpdate(10L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> service.persistGithubPullRequestContributions(
+			10L,
+			100L,
+			List.of(new GithubPullRequestInfo(
+				1001L,
+				10L,
+				"Add contribution sync",
+				501L,
+				"dev-a",
+				"closed",
+				Instant.parse("2026-05-02T10:00:00Z"),
+				120,
+				15,
+				8,
+				"https://github.com/student-team-org/backend/pull/10"
+			))
+		))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.PROJECT_GROUP_NOT_FOUND.getCode());
+
+		verify(githubPullRequestContributionRepository, never())
+			.findByProjectGroup_IdAndGithubRepositoryIdAndGithubPrId(any(), any(), any());
+		verify(githubPullRequestContributionRepository, never()).saveAll(any());
+	}
+
 	private ProjectGroup projectGroup() {
-		return ProjectGroup.builder()
+		ProjectGroup projectGroup = ProjectGroup.builder()
 			.projectName("TeamPo")
 			.projectTitle("TeamPo")
 			.status(ProjectGroupStatus.ACTIVE)
 			.build();
+		ReflectionTestUtils.setField(projectGroup, "id", 10L);
+		return projectGroup;
 	}
 
 	private GithubInstallation githubInstallation() {

--- a/src/test/java/team/po/feature/teamspace/service/TeamspacePersistenceTxServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspacePersistenceTxServiceTest.java
@@ -302,6 +302,7 @@ class TeamspacePersistenceTxServiceTest {
 			120,
 			15,
 			8,
+			2,
 			"https://github.com/student-team-org/backend/pull/10"
 		);
 		GithubPullRequestInfo newPullRequest = new GithubPullRequestInfo(
@@ -315,6 +316,7 @@ class TeamspacePersistenceTxServiceTest {
 			80,
 			5,
 			4,
+			1,
 			"https://github.com/student-team-org/backend/pull/11"
 		);
 		when(projectGroupRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(projectGroup));
@@ -344,6 +346,7 @@ class TeamspacePersistenceTxServiceTest {
 		assertThat(existingContribution.getAdditions()).isEqualTo(120);
 		assertThat(existingContribution.getDeletions()).isEqualTo(15);
 		assertThat(existingContribution.getChangedFiles()).isEqualTo(8);
+		assertThat(existingContribution.getLinkedIssueCount()).isEqualTo(2);
 		assertThat(existingContribution.getSyncedAt()).isNotNull();
 
 		ArgumentCaptor<List<GithubPullRequestContribution>> contributionCaptor = ArgumentCaptor.forClass(List.class);
@@ -360,7 +363,7 @@ class TeamspacePersistenceTxServiceTest {
 		assertThat(newContribution.getAdditions()).isEqualTo(80);
 		assertThat(newContribution.getDeletions()).isEqualTo(5);
 		assertThat(newContribution.getChangedFiles()).isEqualTo(4);
-		assertThat(newContribution.getLinkedIssueCount()).isZero();
+		assertThat(newContribution.getLinkedIssueCount()).isEqualTo(1);
 		assertThat(newContribution.getSyncedAt()).isNotNull();
 	}
 
@@ -382,6 +385,7 @@ class TeamspacePersistenceTxServiceTest {
 				120,
 				15,
 				8,
+				0,
 				"https://github.com/student-team-org/backend/pull/10"
 			))
 		))

--- a/src/test/java/team/po/feature/teamspace/service/TeamspacePersistenceTxServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspacePersistenceTxServiceTest.java
@@ -269,7 +269,7 @@ class TeamspacePersistenceTxServiceTest {
 	}
 
 	@Test
-	void persistGithubPullRequestContributions_updatesExistingAndSavesNewContributions() {
+	void persistGithubPullRequestContributions_skipsExistingAndSavesNewContributions() {
 		ProjectGroup projectGroup = projectGroup();
 		GithubPullRequestContribution existingContribution = GithubPullRequestContribution.builder()
 			.projectGroup(projectGroup)
@@ -338,16 +338,16 @@ class TeamspacePersistenceTxServiceTest {
 		);
 
 		verify(projectGroupRepository).findByIdForUpdate(10L);
-		assertThat(existingContribution.getTitle()).isEqualTo("Add contribution sync");
-		assertThat(existingContribution.getAuthorGithubUsername()).isEqualTo("dev-a");
-		assertThat(existingContribution.getState()).isEqualTo("closed");
-		assertThat(existingContribution.isMerged()).isTrue();
-		assertThat(existingContribution.getMergedAt()).isEqualTo(mergedAt);
-		assertThat(existingContribution.getAdditions()).isEqualTo(120);
-		assertThat(existingContribution.getDeletions()).isEqualTo(15);
-		assertThat(existingContribution.getChangedFiles()).isEqualTo(8);
-		assertThat(existingContribution.getLinkedIssueCount()).isEqualTo(2);
-		assertThat(existingContribution.getSyncedAt()).isNotNull();
+		assertThat(existingContribution.getTitle()).isEqualTo("Old title");
+		assertThat(existingContribution.getAuthorGithubUsername()).isEqualTo("old-dev");
+		assertThat(existingContribution.getState()).isEqualTo("open");
+		assertThat(existingContribution.isMerged()).isFalse();
+		assertThat(existingContribution.getMergedAt()).isNull();
+		assertThat(existingContribution.getAdditions()).isEqualTo(1);
+		assertThat(existingContribution.getDeletions()).isEqualTo(2);
+		assertThat(existingContribution.getChangedFiles()).isEqualTo(1);
+		assertThat(existingContribution.getLinkedIssueCount()).isEqualTo(0);
+		assertThat(existingContribution.getSyncedAt()).isEqualTo(Instant.parse("2026-05-01T00:00:00Z"));
 
 		ArgumentCaptor<List<GithubPullRequestContribution>> contributionCaptor = ArgumentCaptor.forClass(List.class);
 		verify(githubPullRequestContributionRepository).saveAll(contributionCaptor.capture());

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -292,7 +292,7 @@ class TeamspaceServiceTest {
 			.privateRepository(true)
 			.build();
 		GithubPullRequestContributionRepository.GithubRepositoryContributionSummary summary =
-			contributionSummary(501L, "dev-a", 3L, 2L, 120L, 15L, 8L);
+			contributionSummary(1L, 501L, "dev-a", 3L, 2L, 120L, 15L, 8L);
 		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_Id(10L, 1L)).thenReturn(true);
 		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
 			10L,
@@ -307,6 +307,7 @@ class TeamspaceServiceTest {
 		assertThat(response.repoName()).isEqualTo("backend");
 		assertThat(response.fullName()).isEqualTo("student-team-org/backend");
 		assertThat(response.contributors()).hasSize(1);
+		assertThat(response.contributors().get(0).userId()).isEqualTo(1L);
 		assertThat(response.contributors().get(0).githubUserId()).isEqualTo(501L);
 		assertThat(response.contributors().get(0).githubUsername()).isEqualTo("dev-a");
 		assertThat(response.contributors().get(0).mergedPrCount()).isEqualTo(3L);
@@ -892,6 +893,7 @@ class TeamspaceServiceTest {
 	}
 
 	private GithubPullRequestContributionRepository.GithubRepositoryContributionSummary contributionSummary(
+		Long userId,
 		Long githubUserId,
 		String githubUsername,
 		long mergedPrCount,
@@ -901,6 +903,11 @@ class TeamspaceServiceTest {
 		long changedFiles
 	) {
 		return new GithubPullRequestContributionRepository.GithubRepositoryContributionSummary() {
+			@Override
+			public Long getUserId() {
+				return userId;
+			}
+
 			@Override
 			public Long getGithubUserId() {
 				return githubUserId;

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,6 +39,8 @@ import team.po.feature.teamspace.dto.CompleteGithubAppInstallationRequest;
 import team.po.feature.teamspace.dto.CreateGithubAppInstallationUrlResponse;
 import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
+import team.po.feature.teamspace.dto.GithubPullRequestInfo;
+import team.po.feature.teamspace.dto.GithubPullRequestSummary;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
@@ -358,6 +361,138 @@ class TeamspaceServiceTest {
 			.isEqualTo(ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE.getCode());
 
 		verify(githubAppClient).getInstallationRepositories(12345L);
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_fetchesMergedPullRequestDetailsAndPersists() {
+		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
+			.projectGroup(projectGroup())
+			.githubInstallation(githubInstallation())
+			.githubRepositoryId(100L)
+			.owner("student-team-org")
+			.repoName("backend")
+			.fullName("student-team-org/backend")
+			.defaultBranch("main")
+			.privateRepository(true)
+			.build();
+		Instant mergedAt = Instant.parse("2026-05-02T10:00:00Z");
+		GithubPullRequestSummary mergedPullRequest = new GithubPullRequestSummary(
+			1001L,
+			10L,
+			"Add contribution sync",
+			501L,
+			"dev-a",
+			"closed",
+			mergedAt,
+			"https://github.com/student-team-org/backend/pull/10"
+		);
+		GithubPullRequestSummary closedUnmergedPullRequest = new GithubPullRequestSummary(
+			1002L,
+			11L,
+			"Close stale PR",
+			502L,
+			"dev-b",
+			"closed",
+			null,
+			"https://github.com/student-team-org/backend/pull/11"
+		);
+		GithubPullRequestInfo pullRequestDetail = new GithubPullRequestInfo(
+			1001L,
+			10L,
+			"Add contribution sync",
+			501L,
+			"dev-a",
+			"closed",
+			mergedAt,
+			120,
+			15,
+			8,
+			"https://github.com/student-team-org/backend/pull/10"
+		);
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			100L
+		)).thenReturn(Optional.of(repository));
+		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+			.thenReturn(List.of(mergedPullRequest, closedUnmergedPullRequest));
+		when(githubAppClient.getPullRequest(12345L, "student-team-org", "backend", 10L))
+			.thenReturn(pullRequestDetail);
+
+		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
+
+		verify(githubAppClient).getClosedPullRequests(12345L, "student-team-org", "backend");
+		verify(githubAppClient).getPullRequest(12345L, "student-team-org", "backend", 10L);
+		verify(githubAppClient, never()).getPullRequest(12345L, "student-team-org", "backend", 11L);
+		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(
+			10L,
+			100L,
+			List.of(pullRequestDetail)
+		);
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_throwsBadRequest_whenRepositoryIsNotRegistered() {
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			999L
+		)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> teamspaceService.syncGithubPullRequestContributions(10L, 999L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE.getCode());
+
+		verify(githubAppClient, never()).getClosedPullRequests(any(), anyString(), anyString());
+		verify(teamspacePersistenceTxService, never()).persistGithubPullRequestContributions(any(), any(), any());
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_withUser_validatesHostAndSyncsRepository() {
+		Users requester = user();
+		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
+			.projectGroup(projectGroup())
+			.githubInstallation(githubInstallation())
+			.githubRepositoryId(100L)
+			.owner("student-team-org")
+			.repoName("backend")
+			.fullName("student-team-org/backend")
+			.defaultBranch("main")
+			.privateRepository(true)
+			.build();
+		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_IdAndGroupRole(10L, 1L, GroupRole.HOST))
+			.thenReturn(true);
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			100L
+		)).thenReturn(Optional.of(repository));
+		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+			.thenReturn(List.of());
+
+		teamspaceService.syncGithubPullRequestContributions(requester, 10L, 100L);
+
+		verify(projectGroupMemberRepository).existsByProjectGroup_IdAndUser_IdAndGroupRole(
+			10L,
+			1L,
+			GroupRole.HOST
+		);
+		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_withUser_throwsForbidden_whenRequesterIsNotHost() {
+		Users requester = user();
+		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_IdAndGroupRole(10L, 1L, GroupRole.HOST))
+			.thenReturn(false);
+
+		assertThatThrownBy(() -> teamspaceService.syncGithubPullRequestContributions(requester, 10L, 100L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.PROJECT_GROUP_PERMISSION_DENIED.getCode());
+
+		verify(projectGroupGithubRepositoryRepository, never())
+			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(any(), any());
+		verify(githubAppClient, never()).getClosedPullRequests(any(), anyString(), anyString());
+		verify(teamspacePersistenceTxService, never()).persistGithubPullRequestContributions(any(), any(), any());
 	}
 
 	@Test

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -496,7 +496,7 @@ class TeamspaceServiceTest {
 		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
 			.thenReturn(Set.of());
 		when(githubAppClient.getPullRequest(12345L, "student-team-org", "backend", 10L))
-			.thenReturn(pullRequestDetail);
+			.thenReturn(Optional.of(pullRequestDetail));
 
 		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
 
@@ -547,6 +547,45 @@ class TeamspaceServiceTest {
 		verify(githubAppClient).getClosedPullRequests(12345L, "student-team-org", "backend");
 		verify(githubPullRequestContributionRepository).findExistingGithubPrIds(10L, 100L, Set.of(1001L));
 		verify(githubAppClient, never()).getPullRequest(any(), anyString(), anyString(), any());
+		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_skipsPullRequest_whenPullRequestDetailUserIsMissing() {
+		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
+			.projectGroup(projectGroup())
+			.githubInstallation(githubInstallation())
+			.githubRepositoryId(100L)
+			.owner("student-team-org")
+			.repoName("backend")
+			.fullName("student-team-org/backend")
+			.defaultBranch("main")
+			.privateRepository(true)
+			.build();
+		GithubPullRequestSummary pullRequest = new GithubPullRequestSummary(
+			1001L,
+			10L,
+			"Old PR from deleted user",
+			501L,
+			"dev-a",
+			"closed",
+			Instant.parse("2026-05-02T10:00:00Z"),
+			"https://github.com/student-team-org/backend/pull/10"
+		);
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			100L
+		)).thenReturn(Optional.of(repository));
+		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+			.thenReturn(List.of(pullRequest));
+		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
+			.thenReturn(Set.of());
+		when(githubAppClient.getPullRequest(12345L, "student-team-org", "backend", 10L))
+			.thenReturn(Optional.empty());
+
+		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
+
+		verify(githubAppClient).getPullRequest(12345L, "student-team-org", "backend", 10L);
 		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
 	}
 

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -492,12 +493,15 @@ class TeamspaceServiceTest {
 		)).thenReturn(Optional.of(repository));
 		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
 			.thenReturn(List.of(mergedPullRequest, closedUnmergedPullRequest));
+		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
+			.thenReturn(Set.of());
 		when(githubAppClient.getPullRequest(12345L, "student-team-org", "backend", 10L))
 			.thenReturn(pullRequestDetail);
 
 		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
 
 		verify(githubAppClient).getClosedPullRequests(12345L, "student-team-org", "backend");
+		verify(githubPullRequestContributionRepository).findExistingGithubPrIds(10L, 100L, Set.of(1001L));
 		verify(githubAppClient).getPullRequest(12345L, "student-team-org", "backend", 10L);
 		verify(githubAppClient, never()).getPullRequest(12345L, "student-team-org", "backend", 11L);
 		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(
@@ -505,6 +509,45 @@ class TeamspaceServiceTest {
 			100L,
 			List.of(pullRequestDetail)
 		);
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_skipsPullRequestDetail_whenMergedPullRequestAlreadyExists() {
+		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
+			.projectGroup(projectGroup())
+			.githubInstallation(githubInstallation())
+			.githubRepositoryId(100L)
+			.owner("student-team-org")
+			.repoName("backend")
+			.fullName("student-team-org/backend")
+			.defaultBranch("main")
+			.privateRepository(true)
+			.build();
+		GithubPullRequestSummary existingPullRequest = new GithubPullRequestSummary(
+			1001L,
+			10L,
+			"Add contribution sync",
+			501L,
+			"dev-a",
+			"closed",
+			Instant.parse("2026-05-02T10:00:00Z"),
+			"https://github.com/student-team-org/backend/pull/10"
+		);
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			100L
+		)).thenReturn(Optional.of(repository));
+		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+			.thenReturn(List.of(existingPullRequest));
+		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
+			.thenReturn(Set.of(1001L));
+
+		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
+
+		verify(githubAppClient).getClosedPullRequests(12345L, "student-team-org", "backend");
+		verify(githubPullRequestContributionRepository).findExistingGithubPrIds(10L, 100L, Set.of(1001L));
+		verify(githubAppClient, never()).getPullRequest(any(), anyString(), anyString(), any());
+		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
 	}
 
 	@Test

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -485,6 +485,7 @@ class TeamspaceServiceTest {
 			120,
 			15,
 			8,
+			2,
 			"https://github.com/student-team-org/backend/pull/10"
 		);
 		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -45,6 +45,7 @@ import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
 import team.po.feature.teamspace.dto.GithubPullRequestInfo;
 import team.po.feature.teamspace.dto.GithubPullRequestSummary;
+import team.po.feature.teamspace.dto.GithubPullRequestSyncContext;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
@@ -449,16 +450,6 @@ class TeamspaceServiceTest {
 
 	@Test
 	void syncGithubPullRequestContributions_fetchesMergedPullRequestDetailsAndPersists() {
-		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
-			.projectGroup(projectGroup())
-			.githubInstallation(githubInstallation())
-			.githubRepositoryId(100L)
-			.owner("student-team-org")
-			.repoName("backend")
-			.fullName("student-team-org/backend")
-			.defaultBranch("main")
-			.privateRepository(true)
-			.build();
 		Instant mergedAt = Instant.parse("2026-05-02T10:00:00Z");
 		GithubPullRequestSummary mergedPullRequest = new GithubPullRequestSummary(
 			1001L,
@@ -494,10 +485,10 @@ class TeamspaceServiceTest {
 			2,
 			"https://github.com/student-team-org/backend/pull/10"
 		);
-		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		when(projectGroupGithubRepositoryRepository.findGithubPullRequestSyncContext(
 			10L,
 			100L
-		)).thenReturn(Optional.of(repository));
+		)).thenReturn(Optional.of(pullRequestSyncContext()));
 		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
 		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of(mergedPullRequest, closedUnmergedPullRequest));
@@ -522,16 +513,6 @@ class TeamspaceServiceTest {
 
 	@Test
 	void syncGithubPullRequestContributions_skipsPullRequestDetail_whenMergedPullRequestAlreadyExists() {
-		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
-			.projectGroup(projectGroup())
-			.githubInstallation(githubInstallation())
-			.githubRepositoryId(100L)
-			.owner("student-team-org")
-			.repoName("backend")
-			.fullName("student-team-org/backend")
-			.defaultBranch("main")
-			.privateRepository(true)
-			.build();
 		GithubPullRequestSummary existingPullRequest = new GithubPullRequestSummary(
 			1001L,
 			10L,
@@ -542,10 +523,10 @@ class TeamspaceServiceTest {
 			Instant.parse("2026-05-02T10:00:00Z"),
 			"https://github.com/student-team-org/backend/pull/10"
 		);
-		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		when(projectGroupGithubRepositoryRepository.findGithubPullRequestSyncContext(
 			10L,
 			100L
-		)).thenReturn(Optional.of(repository));
+		)).thenReturn(Optional.of(pullRequestSyncContext()));
 		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
 		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of(existingPullRequest));
@@ -563,16 +544,6 @@ class TeamspaceServiceTest {
 
 	@Test
 	void syncGithubPullRequestContributions_findsExistingPullRequestIdsInChunks() {
-		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
-			.projectGroup(projectGroup())
-			.githubInstallation(githubInstallation())
-			.githubRepositoryId(100L)
-			.owner("student-team-org")
-			.repoName("backend")
-			.fullName("student-team-org/backend")
-			.defaultBranch("main")
-			.privateRepository(true)
-			.build();
 		Instant mergedAt = Instant.parse("2026-05-02T10:00:00Z");
 		List<GithubPullRequestSummary> mergedPullRequests = LongStream.rangeClosed(1, 1001)
 			.mapToObj(index -> new GithubPullRequestSummary(
@@ -590,10 +561,10 @@ class TeamspaceServiceTest {
 			.map(GithubPullRequestSummary::githubPullRequestId)
 			.collect(Collectors.toSet());
 
-		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		when(projectGroupGithubRepositoryRepository.findGithubPullRequestSyncContext(
 			10L,
 			100L
-		)).thenReturn(Optional.of(repository));
+		)).thenReturn(Optional.of(pullRequestSyncContext()));
 		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
 		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(mergedPullRequests);
@@ -617,16 +588,6 @@ class TeamspaceServiceTest {
 
 	@Test
 	void syncGithubPullRequestContributions_skipsPullRequest_whenPullRequestDetailUserIsMissing() {
-		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
-			.projectGroup(projectGroup())
-			.githubInstallation(githubInstallation())
-			.githubRepositoryId(100L)
-			.owner("student-team-org")
-			.repoName("backend")
-			.fullName("student-team-org/backend")
-			.defaultBranch("main")
-			.privateRepository(true)
-			.build();
 		GithubPullRequestSummary pullRequest = new GithubPullRequestSummary(
 			1001L,
 			10L,
@@ -637,10 +598,10 @@ class TeamspaceServiceTest {
 			Instant.parse("2026-05-02T10:00:00Z"),
 			"https://github.com/student-team-org/backend/pull/10"
 		);
-		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		when(projectGroupGithubRepositoryRepository.findGithubPullRequestSyncContext(
 			10L,
 			100L
-		)).thenReturn(Optional.of(repository));
+		)).thenReturn(Optional.of(pullRequestSyncContext()));
 		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
 		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of(pullRequest));
@@ -657,7 +618,7 @@ class TeamspaceServiceTest {
 
 	@Test
 	void syncGithubPullRequestContributions_throwsBadRequest_whenRepositoryIsNotRegistered() {
-		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		when(projectGroupGithubRepositoryRepository.findGithubPullRequestSyncContext(
 			10L,
 			999L
 		)).thenReturn(Optional.empty());
@@ -674,22 +635,12 @@ class TeamspaceServiceTest {
 	@Test
 	void syncGithubPullRequestContributions_withUser_validatesHostAndSyncsRepository() {
 		Users requester = user();
-		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
-			.projectGroup(projectGroup())
-			.githubInstallation(githubInstallation())
-			.githubRepositoryId(100L)
-			.owner("student-team-org")
-			.repoName("backend")
-			.fullName("student-team-org/backend")
-			.defaultBranch("main")
-			.privateRepository(true)
-			.build();
 		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_IdAndGroupRole(10L, 1L, GroupRole.HOST))
 			.thenReturn(true);
-		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+		when(projectGroupGithubRepositoryRepository.findGithubPullRequestSyncContext(
 			10L,
 			100L
-		)).thenReturn(Optional.of(repository));
+		)).thenReturn(Optional.of(pullRequestSyncContext()));
 		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
 		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of());
@@ -716,7 +667,7 @@ class TeamspaceServiceTest {
 			.isEqualTo(ErrorCode.PROJECT_GROUP_PERMISSION_DENIED.getCode());
 
 		verify(projectGroupGithubRepositoryRepository, never())
-			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(any(), any());
+			.findGithubPullRequestSyncContext(any(), any());
 		verify(githubAppClient, never()).createPullRequestSyncSession(any());
 		verify(teamspacePersistenceTxService, never()).persistGithubPullRequestContributions(any(), any(), any());
 	}
@@ -1027,6 +978,14 @@ class TeamspaceServiceTest {
 			98765L,
 			"student-team-org",
 			GithubInstallation.ORGANIZATION_ACCOUNT_TYPE
+		);
+	}
+
+	private GithubPullRequestSyncContext pullRequestSyncContext() {
+		return new GithubPullRequestSyncContext(
+			12345L,
+			"student-team-org",
+			"backend"
 		);
 	}
 

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -85,6 +85,9 @@ class TeamspaceServiceTest {
 	private GithubAppClient githubAppClient;
 
 	@Mock
+	private GithubPullRequestSyncSession pullRequestSyncSession;
+
+	@Mock
 	private GithubTokenEncryptor githubTokenEncryptor;
 
 	@Mock
@@ -492,19 +495,21 @@ class TeamspaceServiceTest {
 			10L,
 			100L
 		)).thenReturn(Optional.of(repository));
-		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
+		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of(mergedPullRequest, closedUnmergedPullRequest));
 		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
 			.thenReturn(Set.of());
-		when(githubAppClient.getPullRequest(12345L, "student-team-org", "backend", 10L))
+		when(pullRequestSyncSession.getPullRequest("student-team-org", "backend", 10L))
 			.thenReturn(Optional.of(pullRequestDetail));
 
 		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
 
-		verify(githubAppClient).getClosedPullRequests(12345L, "student-team-org", "backend");
+		verify(githubAppClient).createPullRequestSyncSession(12345L);
+		verify(pullRequestSyncSession).getClosedPullRequests("student-team-org", "backend");
 		verify(githubPullRequestContributionRepository).findExistingGithubPrIds(10L, 100L, Set.of(1001L));
-		verify(githubAppClient).getPullRequest(12345L, "student-team-org", "backend", 10L);
-		verify(githubAppClient, never()).getPullRequest(12345L, "student-team-org", "backend", 11L);
+		verify(pullRequestSyncSession).getPullRequest("student-team-org", "backend", 10L);
+		verify(pullRequestSyncSession, never()).getPullRequest("student-team-org", "backend", 11L);
 		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(
 			10L,
 			100L,
@@ -538,16 +543,18 @@ class TeamspaceServiceTest {
 			10L,
 			100L
 		)).thenReturn(Optional.of(repository));
-		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
+		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of(existingPullRequest));
 		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
 			.thenReturn(Set.of(1001L));
 
 		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
 
-		verify(githubAppClient).getClosedPullRequests(12345L, "student-team-org", "backend");
+		verify(githubAppClient).createPullRequestSyncSession(12345L);
+		verify(pullRequestSyncSession).getClosedPullRequests("student-team-org", "backend");
 		verify(githubPullRequestContributionRepository).findExistingGithubPrIds(10L, 100L, Set.of(1001L));
-		verify(githubAppClient, never()).getPullRequest(any(), anyString(), anyString(), any());
+		verify(pullRequestSyncSession, never()).getPullRequest(anyString(), anyString(), any());
 		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
 	}
 
@@ -577,16 +584,17 @@ class TeamspaceServiceTest {
 			10L,
 			100L
 		)).thenReturn(Optional.of(repository));
-		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
+		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of(pullRequest));
 		when(githubPullRequestContributionRepository.findExistingGithubPrIds(10L, 100L, Set.of(1001L)))
 			.thenReturn(Set.of());
-		when(githubAppClient.getPullRequest(12345L, "student-team-org", "backend", 10L))
+		when(pullRequestSyncSession.getPullRequest("student-team-org", "backend", 10L))
 			.thenReturn(Optional.empty());
 
 		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
 
-		verify(githubAppClient).getPullRequest(12345L, "student-team-org", "backend", 10L);
+		verify(pullRequestSyncSession).getPullRequest("student-team-org", "backend", 10L);
 		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
 	}
 
@@ -602,7 +610,7 @@ class TeamspaceServiceTest {
 			.extracting("code")
 			.isEqualTo(ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE.getCode());
 
-		verify(githubAppClient, never()).getClosedPullRequests(any(), anyString(), anyString());
+		verify(githubAppClient, never()).createPullRequestSyncSession(any());
 		verify(teamspacePersistenceTxService, never()).persistGithubPullRequestContributions(any(), any(), any());
 	}
 
@@ -625,7 +633,8 @@ class TeamspaceServiceTest {
 			10L,
 			100L
 		)).thenReturn(Optional.of(repository));
-		when(githubAppClient.getClosedPullRequests(12345L, "student-team-org", "backend"))
+		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
+		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
 			.thenReturn(List.of());
 
 		teamspaceService.syncGithubPullRequestContributions(requester, 10L, 100L);
@@ -651,7 +660,7 @@ class TeamspaceServiceTest {
 
 		verify(projectGroupGithubRepositoryRepository, never())
 			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(any(), any());
-		verify(githubAppClient, never()).getClosedPullRequests(any(), anyString(), anyString());
+		verify(githubAppClient, never()).createPullRequestSyncSession(any());
 		verify(teamspacePersistenceTxService, never()).persistGithubPullRequestContributions(any(), any(), any());
 	}
 

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +16,8 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -554,6 +557,60 @@ class TeamspaceServiceTest {
 		verify(githubAppClient).createPullRequestSyncSession(12345L);
 		verify(pullRequestSyncSession).getClosedPullRequests("student-team-org", "backend");
 		verify(githubPullRequestContributionRepository).findExistingGithubPrIds(10L, 100L, Set.of(1001L));
+		verify(pullRequestSyncSession, never()).getPullRequest(anyString(), anyString(), any());
+		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
+	}
+
+	@Test
+	void syncGithubPullRequestContributions_findsExistingPullRequestIdsInChunks() {
+		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
+			.projectGroup(projectGroup())
+			.githubInstallation(githubInstallation())
+			.githubRepositoryId(100L)
+			.owner("student-team-org")
+			.repoName("backend")
+			.fullName("student-team-org/backend")
+			.defaultBranch("main")
+			.privateRepository(true)
+			.build();
+		Instant mergedAt = Instant.parse("2026-05-02T10:00:00Z");
+		List<GithubPullRequestSummary> mergedPullRequests = LongStream.rangeClosed(1, 1001)
+			.mapToObj(index -> new GithubPullRequestSummary(
+				100000L + index,
+				index,
+				"PR " + index,
+				501L,
+				"dev-a",
+				"closed",
+				mergedAt,
+				"https://github.com/student-team-org/backend/pull/" + index
+			))
+			.toList();
+		Set<Long> mergedGithubPrIds = mergedPullRequests.stream()
+			.map(GithubPullRequestSummary::githubPullRequestId)
+			.collect(Collectors.toSet());
+
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			100L
+		)).thenReturn(Optional.of(repository));
+		when(githubAppClient.createPullRequestSyncSession(12345L)).thenReturn(pullRequestSyncSession);
+		when(pullRequestSyncSession.getClosedPullRequests("student-team-org", "backend"))
+			.thenReturn(mergedPullRequests);
+		when(githubPullRequestContributionRepository.findExistingGithubPrIds(eq(10L), eq(100L), any()))
+			.thenAnswer(invocation -> invocation.getArgument(2));
+
+		teamspaceService.syncGithubPullRequestContributions(10L, 100L);
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<Set<Long>> githubPrIdsCaptor = ArgumentCaptor.forClass(Set.class);
+		verify(githubPullRequestContributionRepository, times(3))
+			.findExistingGithubPrIds(eq(10L), eq(100L), githubPrIdsCaptor.capture());
+		assertThat(githubPrIdsCaptor.getAllValues())
+			.hasSize(3)
+			.allSatisfy(chunk -> assertThat(chunk).hasSizeLessThanOrEqualTo(500));
+		assertThat(githubPrIdsCaptor.getAllValues().stream().flatMap(Set::stream).collect(Collectors.toSet()))
+			.containsExactlyInAnyOrderElementsOf(mergedGithubPrIds);
 		verify(pullRequestSyncSession, never()).getPullRequest(anyString(), anyString(), any());
 		verify(teamspacePersistenceTxService).persistGithubPullRequestContributions(10L, 100L, List.of());
 	}

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -44,6 +44,7 @@ import team.po.feature.teamspace.dto.GithubPullRequestSummary;
 import team.po.feature.teamspace.dto.GithubRepositorySettingContext;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.repository.GithubInstallationRepository;
+import team.po.feature.teamspace.repository.GithubPullRequestContributionRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubInstallationRepository;
 import team.po.feature.teamspace.repository.ProjectGroupGithubRepositoryRepository;
 import team.po.feature.user.domain.GithubAccount;
@@ -88,6 +89,9 @@ class TeamspaceServiceTest {
 	@Mock
 	private TeamspacePersistenceTxService teamspacePersistenceTxService;
 
+	@Mock
+	private GithubPullRequestContributionRepository githubPullRequestContributionRepository;
+
 	private TeamspaceService teamspaceService;
 
 	@BeforeEach
@@ -111,7 +115,8 @@ class TeamspaceServiceTest {
 			githubAppProperties,
 			githubAppClient,
 			githubTokenEncryptor,
-			teamspacePersistenceTxService
+			teamspacePersistenceTxService,
+			githubPullRequestContributionRepository
 		);
 	}
 
@@ -271,6 +276,77 @@ class TeamspaceServiceTest {
 			.isEqualTo(ErrorCode.PROJECT_GROUP_PERMISSION_DENIED.getCode());
 
 		verify(projectGroupGithubRepositoryRepository, never()).findAllByProjectGroup_IdAndDeletedAtIsNull(10L);
+	}
+
+	@Test
+	void getGithubRepositoryContributions_returnsContributorSummaries_whenRequesterIsMember() {
+		Users requester = user();
+		ProjectGroupGithubRepository repository = ProjectGroupGithubRepository.builder()
+			.projectGroup(projectGroup())
+			.githubInstallation(githubInstallation())
+			.githubRepositoryId(100L)
+			.owner("student-team-org")
+			.repoName("backend")
+			.fullName("student-team-org/backend")
+			.defaultBranch("main")
+			.privateRepository(true)
+			.build();
+		GithubPullRequestContributionRepository.GithubRepositoryContributionSummary summary =
+			contributionSummary(501L, "dev-a", 3L, 2L, 120L, 15L, 8L);
+		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_Id(10L, 1L)).thenReturn(true);
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			100L
+		)).thenReturn(Optional.of(repository));
+		when(githubPullRequestContributionRepository.findContributionSummaries(10L, 100L))
+			.thenReturn(List.of(summary));
+
+		var response = teamspaceService.getGithubRepositoryContributions(requester, 10L, 100L);
+
+		assertThat(response.githubRepositoryId()).isEqualTo(100L);
+		assertThat(response.repoName()).isEqualTo("backend");
+		assertThat(response.fullName()).isEqualTo("student-team-org/backend");
+		assertThat(response.contributors()).hasSize(1);
+		assertThat(response.contributors().get(0).githubUserId()).isEqualTo(501L);
+		assertThat(response.contributors().get(0).githubUsername()).isEqualTo("dev-a");
+		assertThat(response.contributors().get(0).mergedPrCount()).isEqualTo(3L);
+		assertThat(response.contributors().get(0).linkedIssueCount()).isEqualTo(2L);
+		assertThat(response.contributors().get(0).additions()).isEqualTo(120L);
+		assertThat(response.contributors().get(0).deletions()).isEqualTo(15L);
+		assertThat(response.contributors().get(0).changedFiles()).isEqualTo(8L);
+		assertThat(response.contributors().get(0).contributionScore()).isEqualTo(40L);
+	}
+
+	@Test
+	void getGithubRepositoryContributions_throwsForbidden_whenRequesterIsNotMember() {
+		Users requester = user();
+		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_Id(10L, 1L)).thenReturn(false);
+
+		assertThatThrownBy(() -> teamspaceService.getGithubRepositoryContributions(requester, 10L, 100L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.PROJECT_GROUP_PERMISSION_DENIED.getCode());
+
+		verify(projectGroupGithubRepositoryRepository, never())
+			.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(any(), any());
+		verify(githubPullRequestContributionRepository, never()).findContributionSummaries(any(), any());
+	}
+
+	@Test
+	void getGithubRepositoryContributions_throwsBadRequest_whenRepositoryIsNotRegistered() {
+		Users requester = user();
+		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_Id(10L, 1L)).thenReturn(true);
+		when(projectGroupGithubRepositoryRepository.findByProjectGroup_IdAndGithubRepositoryIdAndDeletedAtIsNull(
+			10L,
+			999L
+		)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> teamspaceService.getGithubRepositoryContributions(requester, 10L, 999L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.GITHUB_REPOSITORY_NOT_ACCESSIBLE.getCode());
+
+		verify(githubPullRequestContributionRepository, never()).findContributionSummaries(any(), any());
 	}
 
 	@Test
@@ -813,5 +889,52 @@ class TeamspaceServiceTest {
 			.build();
 		ReflectionTestUtils.setField(user, "id", 1L);
 		return user;
+	}
+
+	private GithubPullRequestContributionRepository.GithubRepositoryContributionSummary contributionSummary(
+		Long githubUserId,
+		String githubUsername,
+		long mergedPrCount,
+		long linkedIssueCount,
+		long additions,
+		long deletions,
+		long changedFiles
+	) {
+		return new GithubPullRequestContributionRepository.GithubRepositoryContributionSummary() {
+			@Override
+			public Long getGithubUserId() {
+				return githubUserId;
+			}
+
+			@Override
+			public String getGithubUsername() {
+				return githubUsername;
+			}
+
+			@Override
+			public long getMergedPrCount() {
+				return mergedPrCount;
+			}
+
+			@Override
+			public long getLinkedIssueCount() {
+				return linkedIssueCount;
+			}
+
+			@Override
+			public long getAdditions() {
+				return additions;
+			}
+
+			@Override
+			public long getDeletions() {
+				return deletions;
+			}
+
+			@Override
+			public long getChangedFiles() {
+				return changedFiles;
+			}
+		};
 	}
 }


### PR DESCRIPTION
  ## 📌 Related Issue
   Closes https://github.com/Team-po/Server/issues/79
  ## 🚀 Description

  팀스페이스 내 GitHub Repository별 기여도 가시화 기능을 구현했습니다.

  - GitHub App 설치/Repository 설정 기반으로 등록된 Repository의 merged PR 기여도를 수집합니다.
  - PR 원천 데이터를 `github_pull_request_contribution` 테이블에 저장합니다.
  - Repository별 contributor 기여도 조회 API를 추가했습니다.
  - 기여도 기준은 `merged PR 수`를 1차 기준으로 사용하고, `linked issue 수`와 변경 라인 수를 보조 지표로 제공합니다.
  - 동기화 API를 통해 GitHub에서 merged PR 정보를 가져와 저장합니다.
  - 동기화 시 이미 저장된 PR은 상세 조회를 건너뛰도록 최적화했습니다.

  ## 📢 Review Point

  - GitHub API 호출과 DB transaction이 분리되어 있는지 확인 부탁드립니다.
    - `TeamspaceService`: GitHub API 호출 및 흐름 조립
    - `TeamspacePersistenceTxService`: PR 기여도 원천 데이터 저장/갱신

  - 수동 동기화 API의 동작을 확인 부탁드립니다.
    - closed PR 목록 조회
    - `mergedAt != null`인 PR만 필터링
    - 이미 저장된 `github_pr_id`는 상세 조회 제외
    - 신규 merged PR만 상세 조회 후 저장

  - 기여도 조회 쿼리의 join 조건을 확인 부탁드립니다.
    - active `github_account`와 매칭되는 사용자만 조회
    - 현재 팀스페이스 멤버인 사용자만 기여도 결과에 포함
    - 팀 외부 contributor 또는 삭제된 GitHub 계정은 제외

  - private repository 정보가 팀스페이스 외부 사용자에게 노출되지 않도록 권한 검증이 적절한지 확인 부탁드립니다.
    - 후보 Repository 조회는 HOST 제한 유지
    - 수동 동기화는 HOST만 가능
    - 기여도 조회는 팀스페이스 멤버만 가능

  - 반복 수동 동기화 시 기존 PR을 재조회하지 않는 최적화가 의도에 맞는지 확인 부탁드립니다.

  ## 📚 Etc (선택)