### PR TITLE
Feat : 주간 요약 단건 조회 API 

### DIFF
--- a/src/main/java/team/po/exception/ErrorCode.java
+++ b/src/main/java/team/po/exception/ErrorCode.java
@@ -78,6 +78,8 @@ public enum ErrorCode {
 		"선택한 GitHub Repository에 접근할 수 없습니다."),
 	GITHUB_REPOSITORY_NOT_CONFIGURED(HttpStatus.BAD_REQUEST, "GITHUB_REPOSITORY_NOT_CONFIGURED",
 		"팀 스페이스에 등록된 GitHub Repository가 없습니다."),
+	GITHUB_WEEKLY_SUMMARY_NOT_FOUND(HttpStatus.NOT_FOUND, "GITHUB_WEEKLY_SUMMARY_NOT_FOUND",
+		"GitHub 주간 요약을 찾을 수 없습니다."),
 	GITHUB_API_REQUEST_FAILED(HttpStatus.BAD_GATEWAY, "GITHUB_API_REQUEST_FAILED", "GitHub API 요청에 실패했습니다."),
 	PROJECT_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_REQUEST_NOT_FOUND", "진행 중인 매칭 요청이 없습니다."),
 	PROJECT_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PROJECT_REQUEST_ALREADY_EXISTS", "이미 진행 중인 매칭 요청이 있습니다."),

--- a/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
+++ b/src/main/java/team/po/feature/teamspace/controller/TeamspaceController.java
@@ -21,6 +21,7 @@ import team.po.feature.teamspace.dto.GetGithubInstallationStatusResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryContributionResponse;
 import team.po.feature.teamspace.dto.GetGithubRepositoryListResponse;
 import team.po.feature.teamspace.dto.GetWeeklyGithubSummaryListResponse;
+import team.po.feature.teamspace.dto.GetWeeklyGithubSummaryResponse;
 import team.po.feature.teamspace.dto.SetGithubRepositoryListRequest;
 import team.po.feature.teamspace.service.TeamspaceService;
 import team.po.feature.user.domain.Users;
@@ -139,6 +140,24 @@ public class TeamspaceController {
 			user,
 			projectGroupId,
 			targetUserId
+		);
+
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "유저 Github 주간 요약 단건 조회 API")
+	@GetMapping("/{projectGroupId}/github/users/{targetUserId}/weekly-summaries/{weeklyGithubSummaryId}")
+	public ResponseEntity<GetWeeklyGithubSummaryResponse> getWeeklyGithubSummary(
+		@Parameter(hidden = true) @LoginUser Users user,
+		@PathVariable Long projectGroupId,
+		@PathVariable Long targetUserId,
+		@PathVariable Long weeklyGithubSummaryId
+	) {
+		GetWeeklyGithubSummaryResponse response = teamspaceService.getWeeklyGithubSummary(
+			user,
+			projectGroupId,
+			targetUserId,
+			weeklyGithubSummaryId
 		);
 
 		return ResponseEntity.ok(response);

--- a/src/main/java/team/po/feature/teamspace/repository/WeeklyGithubSummaryRepository.java
+++ b/src/main/java/team/po/feature/teamspace/repository/WeeklyGithubSummaryRepository.java
@@ -15,5 +15,7 @@ public interface WeeklyGithubSummaryRepository extends JpaRepository<WeeklyGithu
 		Instant periodEnd
 	);
 
+	Optional<WeeklyGithubSummary> findByIdAndProjectGroupMember_Id(Long id, Long projectGroupMemberId);
+
 	List<WeeklyGithubSummary> findAllByProjectGroupMember_IdOrderByPeriodEndDesc(Long projectGroupMemberId);
 }

--- a/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
+++ b/src/main/java/team/po/feature/teamspace/service/TeamspaceService.java
@@ -382,36 +382,35 @@ public class TeamspaceService {
 		Long projectGroupId,
 		Long targetUserId
 	) {
-		projectGroupMemberRepository
-			.findByProjectGroup_IdAndUser_Id(projectGroupId, user.getId())
-			.orElseThrow(() -> new ApplicationException(
-				ErrorCode.PROJECT_GROUP_PERMISSION_DENIED,
-				"팀 스페이스 멤버만 Github 주간 요약을 조회할 수 있습니다."
-			));
-
-		ProjectGroupMember targetMember = projectGroupMemberRepository
-			.findByProjectGroup_IdAndUser_Id(projectGroupId, targetUserId)
-			.orElseThrow(() -> new ApplicationException(
-				ErrorCode.PROJECT_GROUP_MEMBER_NOT_FOUND,
-				"Github 주간 요약 조회 대상 팀 스페이스 멤버를 찾을 수 없습니다."
-			));
+		ProjectGroupMember targetMember = validateWeeklyGithubSummaryReadable(user, projectGroupId, targetUserId);
 
 		List<GetWeeklyGithubSummaryResponse> summaries = weeklyGithubSummaryRepository
 			.findAllByProjectGroupMember_IdOrderByPeriodEndDesc(targetMember.getId())
 			.stream()
-			.map(weeklyGithubSummary -> new GetWeeklyGithubSummaryResponse(
-				weeklyGithubSummary.getId(),
-				weeklyGithubSummary.getPeriodStart(),
-				weeklyGithubSummary.getPeriodEnd(),
-				weeklyGithubSummary.getSourcePrCount(),
-				weeklyGithubSummary.getSourceIssueCount(),
-				parseGeneratedWeeklySummary(weeklyGithubSummary.getSummaryJson(), targetMember.getId())
-			))
+			.map(weeklyGithubSummary -> toGetWeeklyGithubSummaryResponse(weeklyGithubSummary, targetMember.getId()))
 			.toList();
 
 		return new GetWeeklyGithubSummaryListResponse(
 			summaries
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public GetWeeklyGithubSummaryResponse getWeeklyGithubSummary(
+		Users user,
+		Long projectGroupId,
+		Long targetUserId,
+		Long weeklyGithubSummaryId
+	) {
+		ProjectGroupMember targetMember = validateWeeklyGithubSummaryReadable(user, projectGroupId, targetUserId);
+		WeeklyGithubSummary weeklyGithubSummary = weeklyGithubSummaryRepository
+			.findByIdAndProjectGroupMember_Id(weeklyGithubSummaryId, targetMember.getId())
+			.orElseThrow(() -> new ApplicationException(
+				ErrorCode.GITHUB_WEEKLY_SUMMARY_NOT_FOUND,
+				"요청한 Github 주간 요약을 찾을 수 없습니다."
+			));
+
+		return toGetWeeklyGithubSummaryResponse(weeklyGithubSummary, targetMember.getId());
 	}
 
 	private Optional<GithubPullRequestInfo> getPullRequestDetail(
@@ -451,6 +450,40 @@ public class TeamspaceService {
 
 	private long calculateContributionScore(long mergedPrCount, long linkedIssueCount) {
 		return mergedPrCount * 10 + linkedIssueCount * 5;
+	}
+
+	private ProjectGroupMember validateWeeklyGithubSummaryReadable(
+		Users user,
+		Long projectGroupId,
+		Long targetUserId
+	) {
+		projectGroupMemberRepository
+			.findByProjectGroup_IdAndUser_Id(projectGroupId, user.getId())
+			.orElseThrow(() -> new ApplicationException(
+				ErrorCode.PROJECT_GROUP_PERMISSION_DENIED,
+				"팀 스페이스 멤버만 Github 주간 요약을 조회할 수 있습니다."
+			));
+
+		return projectGroupMemberRepository
+			.findByProjectGroup_IdAndUser_Id(projectGroupId, targetUserId)
+			.orElseThrow(() -> new ApplicationException(
+				ErrorCode.PROJECT_GROUP_MEMBER_NOT_FOUND,
+				"Github 주간 요약 조회 대상 팀 스페이스 멤버를 찾을 수 없습니다."
+			));
+	}
+
+	private GetWeeklyGithubSummaryResponse toGetWeeklyGithubSummaryResponse(
+		WeeklyGithubSummary weeklyGithubSummary,
+		Long projectGroupMemberId
+	) {
+		return new GetWeeklyGithubSummaryResponse(
+			weeklyGithubSummary.getId(),
+			weeklyGithubSummary.getPeriodStart(),
+			weeklyGithubSummary.getPeriodEnd(),
+			weeklyGithubSummary.getSourcePrCount(),
+			weeklyGithubSummary.getSourceIssueCount(),
+			parseGeneratedWeeklySummary(weeklyGithubSummary.getSummaryJson(), projectGroupMemberId)
+		);
 	}
 
 	private GithubWeeklySummaryContent parseGeneratedWeeklySummary(String summaryJson, Long projectGroupMemberId) {

--- a/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
+++ b/src/test/java/team/po/feature/teamspace/controller/TeamspaceControllerTest.java
@@ -294,4 +294,35 @@ class TeamspaceControllerTest {
 
 		verify(teamspaceService).getWeeklyGithubSummaries(mockUser, 10L, 2L);
 	}
+
+	@Test
+	void getWeeklyGithubSummary_returnsOk() throws Exception {
+		when(teamspaceService.getWeeklyGithubSummary(mockUser, 10L, 2L, 1000L))
+			.thenReturn(new GetWeeklyGithubSummaryResponse(
+				1000L,
+				Instant.parse("2026-05-25T15:00:00Z"),
+				Instant.parse("2026-06-01T15:00:00Z"),
+				3,
+				2,
+				new GithubWeeklySummaryContent(
+					"지난 주 Github 활동 요약",
+					List.of("주간 요약 조회 API 구현"),
+					List.of("PR #10 요약 조회 API 추가"),
+					List.of("Issue #82 주간 요약 기능 정리"),
+					List.of("프론트엔드 조회 화면 연동")
+				)
+			));
+
+		mockMvc.perform(get("/api/team-space/10/github/users/2/weekly-summaries/1000"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.weeklyGithubSummaryId").value(1000))
+			.andExpect(jsonPath("$.periodStart").value("2026-05-25T15:00:00Z"))
+			.andExpect(jsonPath("$.periodEnd").value("2026-06-01T15:00:00Z"))
+			.andExpect(jsonPath("$.sourcePrCount").value(3))
+			.andExpect(jsonPath("$.sourceIssueCount").value(2))
+			.andExpect(jsonPath("$.summary.summary").value("지난 주 Github 활동 요약"))
+			.andExpect(jsonPath("$.summary.mainActivities[0]").value("주간 요약 조회 API 구현"));
+
+		verify(teamspaceService).getWeeklyGithubSummary(mockUser, 10L, 2L, 1000L);
+	}
 }

--- a/src/test/java/team/po/feature/teamspace/repository/WeeklyGithubSummaryRepositoryTest.java
+++ b/src/test/java/team/po/feature/teamspace/repository/WeeklyGithubSummaryRepositoryTest.java
@@ -67,6 +67,40 @@ class WeeklyGithubSummaryRepositoryTest {
 	}
 
 	@Test
+	void findByIdAndProjectGroupMemberId_returnsWeeklyGithubSummary() {
+		Instant periodStart = Instant.parse("2026-05-25T00:00:00Z");
+		Instant periodEnd = Instant.parse("2026-06-01T00:00:00Z");
+		insertUser(1L, "member@example.com", "member");
+		insertProjectGroup(10L);
+		insertProjectGroupMember(100L, 1L, 10L);
+		insertWeeklyGithubSummary(1000L, 100L, 1L, periodStart, periodEnd);
+		entityManager.flush();
+		entityManager.clear();
+
+		WeeklyGithubSummary summary = repository.findByIdAndProjectGroupMember_Id(1000L, 100L)
+			.orElseThrow();
+
+		assertThat(summary.getId()).isEqualTo(1000L);
+		assertThat(summary.getProjectGroupMember().getId()).isEqualTo(100L);
+	}
+
+	@Test
+	void findByIdAndProjectGroupMemberId_returnsEmpty_whenProjectGroupMemberIsDifferent() {
+		Instant periodStart = Instant.parse("2026-05-25T00:00:00Z");
+		Instant periodEnd = Instant.parse("2026-06-01T00:00:00Z");
+		insertUser(1L, "member@example.com", "member");
+		insertUser(2L, "other@example.com", "other");
+		insertProjectGroup(10L);
+		insertProjectGroupMember(100L, 1L, 10L);
+		insertProjectGroupMember(200L, 2L, 10L);
+		insertWeeklyGithubSummary(1000L, 100L, 1L, periodStart, periodEnd);
+		entityManager.flush();
+		entityManager.clear();
+
+		assertThat(repository.findByIdAndProjectGroupMember_Id(1000L, 200L)).isEmpty();
+	}
+
+	@Test
 	void save_persistsUpdatedWeeklyGithubSummary() {
 		Instant periodStart = Instant.parse("2026-05-25T00:00:00Z");
 		Instant periodEnd = Instant.parse("2026-06-01T00:00:00Z");

--- a/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
+++ b/src/test/java/team/po/feature/teamspace/service/TeamspaceServiceTest.java
@@ -998,6 +998,90 @@ class TeamspaceServiceTest {
 	}
 
 	@Test
+	void getWeeklyGithubSummary_returnsTargetUserSavedSummary() {
+		Users requester = user();
+		WeeklyGithubSummary savedSummary = weeklyGithubSummary(
+			1000L,
+			weeklySummaryJson(),
+			1,
+			1
+		);
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 1L))
+			.thenReturn(Optional.of(projectGroupMember()));
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 2L))
+			.thenReturn(Optional.of(projectGroupMember(200L, 2L)));
+		when(weeklyGithubSummaryRepository.findByIdAndProjectGroupMember_Id(1000L, 200L))
+			.thenReturn(Optional.of(savedSummary));
+
+		GetWeeklyGithubSummaryResponse response = teamspaceService.getWeeklyGithubSummary(
+			requester,
+			10L,
+			2L,
+			1000L
+		);
+
+		assertThat(response.weeklyGithubSummaryId()).isEqualTo(1000L);
+		assertThat(response.periodStart()).isEqualTo(Instant.parse("2026-05-25T00:00:00Z"));
+		assertThat(response.periodEnd()).isEqualTo(Instant.parse("2026-06-01T00:00:00Z"));
+		assertThat(response.sourcePrCount()).isEqualTo(1);
+		assertThat(response.sourceIssueCount()).isEqualTo(1);
+		assertThat(response.summary().summary()).isEqualTo("이번 주에는 Github 주간 요약 API 기반 작업이 진행되었습니다.");
+		verify(weeklyGithubSummaryRepository).findByIdAndProjectGroupMember_Id(1000L, 200L);
+		verifyNoInteractions(githubAppClient, geminiClient);
+	}
+
+	@Test
+	void getWeeklyGithubSummary_throwsForbidden_whenRequesterIsNotMember() {
+		Users requester = user();
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 1L))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> teamspaceService.getWeeklyGithubSummary(requester, 10L, 2L, 1000L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.PROJECT_GROUP_PERMISSION_DENIED.getCode());
+
+		verify(weeklyGithubSummaryRepository, never()).findByIdAndProjectGroupMember_Id(any(), any());
+		verifyNoInteractions(githubAppClient, geminiClient);
+	}
+
+	@Test
+	void getWeeklyGithubSummary_throwsNotFound_whenTargetUserIsNotMember() {
+		Users requester = user();
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 1L))
+			.thenReturn(Optional.of(projectGroupMember()));
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 2L))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> teamspaceService.getWeeklyGithubSummary(requester, 10L, 2L, 1000L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.PROJECT_GROUP_MEMBER_NOT_FOUND.getCode());
+
+		verify(weeklyGithubSummaryRepository, never()).findByIdAndProjectGroupMember_Id(any(), any());
+		verifyNoInteractions(githubAppClient, geminiClient);
+	}
+
+	@Test
+	void getWeeklyGithubSummary_throwsNotFound_whenSummaryDoesNotExistForTargetUser() {
+		Users requester = user();
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 1L))
+			.thenReturn(Optional.of(projectGroupMember()));
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 2L))
+			.thenReturn(Optional.of(projectGroupMember(200L, 2L)));
+		when(weeklyGithubSummaryRepository.findByIdAndProjectGroupMember_Id(1000L, 200L))
+			.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> teamspaceService.getWeeklyGithubSummary(requester, 10L, 2L, 1000L))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.GITHUB_WEEKLY_SUMMARY_NOT_FOUND.getCode());
+
+		verify(weeklyGithubSummaryRepository).findByIdAndProjectGroupMember_Id(1000L, 200L);
+		verifyNoInteractions(githubAppClient, geminiClient);
+	}
+
+	@Test
 	void createGithubAppInstallationUrl_savesStateAndReturnsGithubInstallUrl() {
 		Users requester = user();
 		when(projectGroupMemberRepository.existsByProjectGroup_IdAndUser_IdAndGroupRole(10L, 1L, GroupRole.HOST))


### PR DESCRIPTION
  ## 📌 Related Issue

  Closes #95

  ## 🚀 Description

  - 유저별 Github 주간 요약 단건 조회 API를 추가했습니다.
    - `GET /api/team-space/{projectGroupId}/github/users/{targetUserId}/weekly-summaries/{weeklyGithubSummaryId}`
  - 기존 주간 요약 목록 조회 로직과 동일하게 요청자가 팀 스페이스 멤버인지 검증합니다.
  - 조회 대상 유저가 해당 팀 스페이스 멤버인지 검증합니다.
  - `weeklyGithubSummaryId`만으로 조회하지 않고, 대상 멤버 ID까지 함께 조건으로 조회하도록 구현했습니다.
    - 다른 유저의 요약 ID를 넣어도 조회되지 않도록 방어합니다.
  - 주간 요약 단건이 없을 때 반환할 `GITHUB_WEEKLY_SUMMARY_NOT_FOUND` 에러 코드를 추가했습니다.
  - 목록 조회와 단건 조회의 응답 변환 로직을 공통 메서드로 분리했습니다.

  ## 📢 Review Point

  - 단건 조회 시 `weeklyGithubSummaryId`와 `targetUserId`가 모두 일치하는 요약만 조회되도록 권한 경계가 잘 지켜지는지 확인 부탁드립
  니다.
  - 기존 목록 조회 API의 응답 구조와 단건 조회 API의 응답 구조가 클라이언트에서 사용하기 적절한지 확인 부탁드립니다.
  - 요약이 존재하지 않는 경우 `GITHUB_WEEKLY_SUMMARY_NOT_FOUND`를 반환하는게 나을지, null값을 반환하는게 나을지, 알려주시면 반영해놓을게요

  ## 📚 Etc (선택)