### PR TITLE
Fix: 매칭 상태 조회 500 오류 방지

### DIFF
--- a/src/main/java/team/po/feature/match/repository/MatchingMemberRepository.java
+++ b/src/main/java/team/po/feature/match/repository/MatchingMemberRepository.java
@@ -39,8 +39,13 @@ public interface MatchingMemberRepository extends JpaRepository<MatchingMember, 
 
 	@Query("""
 		SELECT mm FROM MatchingMember mm
-		WHERE mm.projectRequest.user.id = :userId
+		JOIN FETCH mm.matchingSession ms
+		JOIN FETCH mm.projectRequest pr
+		JOIN FETCH pr.user u
+		WHERE u.id = :userId
 		  AND mm.deletedAt IS NULL
+		  AND ms.deletedAt IS NULL
+		  AND pr.status = team.po.feature.match.enums.Status.MATCHING
 		""")
 	Optional<MatchingMember> findCurrentActiveByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
+++ b/src/main/java/team/po/feature/match/repository/ProjectRequestRepository.java
@@ -5,9 +5,11 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import jakarta.persistence.LockModeType;
 import team.po.feature.match.domain.ProjectRequest;
 import team.po.feature.match.enums.Role;
 import team.po.feature.match.enums.Status;
@@ -16,6 +18,23 @@ public interface ProjectRequestRepository extends JpaRepository<ProjectRequest, 
 	public boolean existsByUserIdAndStatusIn(Long userId, List<Status> statuses);
 
 	public Optional<ProjectRequest> findByUserIdAndStatusIn(Long userId, List<Status> statuses);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT pr FROM ProjectRequest pr
+		JOIN FETCH pr.user
+		WHERE pr.id = :id
+		""")
+	Optional<ProjectRequest> findByIdWithLock(@Param("id") Long id);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT pr FROM ProjectRequest pr
+		JOIN FETCH pr.user
+		WHERE pr.id IN :ids
+		ORDER BY pr.id ASC
+		""")
+	List<ProjectRequest> findAllByIdInWithLock(@Param("ids") List<Long> ids);
 
 	// MATCHING
 	// Host 대기자 조회: WAITING && isHost

--- a/src/main/java/team/po/feature/match/service/MatchService.java
+++ b/src/main/java/team/po/feature/match/service/MatchService.java
@@ -1,7 +1,11 @@
 package team.po.feature.match.service;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -50,15 +54,35 @@ public class MatchService {
 	// 신규 매칭 세션 생성
 	@Transactional
 	public void createMatchingSession(Long hostRequestId, List<Long> memberRequestIds) {
-		// 1-1. ProjectRequest 재조회 (managed 상태)
-		ProjectRequest host = projectRequestRepository.findById(hostRequestId)
-			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND));
-		List<ProjectRequest> members = projectRequestRepository.findAllById(memberRequestIds);
+		// 1-1. ProjectRequest 재조회 및 잠금 (managed 상태)
+		List<Long> requestIds = new ArrayList<>(new LinkedHashSet<>(memberRequestIds));
+		requestIds.add(hostRequestId);
+		requestIds = requestIds.stream()
+			.distinct()
+			.sorted()
+			.toList();
 
-		if (members.size() != memberRequestIds.size()) {
-			log.error("매칭 멤버 ProjectRequest 조회 누락");
+		if (requestIds.size() != memberRequestIds.size() + 1) {
+			log.error("중복된 ProjectRequest로 매칭 세션 생성 요청: hostRequestId={}, memberRequestCount={}",
+				hostRequestId, memberRequestIds.size());
+			throw new ApplicationException(ErrorCode.MATCH_DATA_ERROR);
+		}
+
+		List<ProjectRequest> lockedRequests = projectRequestRepository.findAllByIdInWithLock(requestIds);
+		if (lockedRequests.size() != requestIds.size()) {
+			log.error("매칭 멤버 ProjectRequest 조회 누락: expected={}, actual={}", requestIds.size(), lockedRequests.size());
 			throw new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND);
 		}
+
+		Map<Long, ProjectRequest> requestsById = lockedRequests.stream()
+			.collect(Collectors.toMap(ProjectRequest::getId, Function.identity()));
+		ProjectRequest host = requestsById.get(hostRequestId);
+		List<ProjectRequest> members = memberRequestIds.stream()
+			.map(requestsById::get)
+			.toList();
+
+		validateWaitingRequest(host);
+		members.forEach(this::validateWaitingRequest);
 
 		// 1-2. 매칭 세션 생성 및 저장
 		MatchingSession session = matchingSessionRepository.save(MatchingSession.create());
@@ -98,7 +122,7 @@ public class MatchService {
 			.orElseThrow(() -> new ApplicationException(ErrorCode.MATCH_NOT_FOUND));
 
 		// ProjectRequest 재조회 (managed 상태)
-		ProjectRequest candidate = projectRequestRepository.findById(candidateRequestId)
+		ProjectRequest candidate = projectRequestRepository.findByIdWithLock(candidateRequestId)
 			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_REQUEST_NOT_FOUND));
 
 		if (candidate.getStatus() != Status.WAITING) {
@@ -384,6 +408,14 @@ public class MatchService {
 	private void validateNotHost(MatchingMember member) {
 		if (member.getProjectRequest().isHostRequest()) {
 			throw new ApplicationException(ErrorCode.MATCH_ACCESS_DENIED);
+		}
+	}
+
+	private void validateWaitingRequest(ProjectRequest projectRequest) {
+		if (projectRequest.getStatus() != Status.WAITING) {
+			log.debug("매칭 세션 생성 스킵 - 요청 상태 변경됨: projectRequestId={}, status={}",
+				projectRequest.getId(), projectRequest.getStatus());
+			throw new ApplicationException(ErrorCode.INVALID_MATCH_STATUS);
 		}
 	}
 

--- a/src/main/resources/db/migration/V26__fix_matching_member_active_uniqueness.sql
+++ b/src/main/resources/db/migration/V26__fix_matching_member_active_uniqueness.sql
@@ -1,0 +1,11 @@
+UPDATE matching_member mm
+JOIN matching_session ms ON ms.id = mm.matching_session_id
+SET mm.deleted_at = ms.deleted_at
+WHERE mm.deleted_at IS NULL
+  AND ms.deleted_at IS NOT NULL;
+
+ALTER TABLE matching_member
+    ADD COLUMN active_project_request_id BIGINT AS (
+        CASE WHEN deleted_at IS NULL THEN project_request_id ELSE NULL END
+    ) VIRTUAL,
+    ADD UNIQUE INDEX uq_matching_member_active_project_request (active_project_request_id);

--- a/src/test/java/team/po/feature/match/repository/MatchingMemberRepositoryTest.java
+++ b/src/test/java/team/po/feature/match/repository/MatchingMemberRepositoryTest.java
@@ -1,0 +1,143 @@
+package team.po.feature.match.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.EntityManager;
+import team.po.feature.match.domain.MatchingMember;
+
+@DataJpaTest
+@ActiveProfiles("h2")
+class MatchingMemberRepositoryTest {
+
+	@Autowired
+	private MatchingMemberRepository repository;
+
+	@Autowired
+	private EntityManager entityManager;
+
+	@Test
+	void findCurrentActiveByUserId_ignoresMembersFromDeletedSessions() {
+		insertUser(1L);
+		insertProjectRequest(10L, 1L, "MATCHED");
+		insertProjectRequest(20L, 1L, "MATCHING");
+		insertMatchingSession(100L, Instant.parse("2026-06-16T08:00:00Z"));
+		insertMatchingSession(200L, null);
+		insertMatchingMember(1000L, 100L, 10L, null);
+		insertMatchingMember(2000L, 200L, 20L, null);
+		entityManager.flush();
+		entityManager.clear();
+
+		Optional<MatchingMember> result = repository.findCurrentActiveByUserId(1L);
+
+		assertThat(result).isPresent();
+		assertThat(result.get().getId()).isEqualTo(2000L);
+		assertThat(result.get().getMatchingSession().getId()).isEqualTo(200L);
+		assertThat(result.get().getProjectRequest().getId()).isEqualTo(20L);
+	}
+
+	@Test
+	void findCurrentActiveByUserId_returnsEmptyWhenOnlyDeletedSessionMemberExists() {
+		insertUser(1L);
+		insertProjectRequest(10L, 1L, "MATCHED");
+		insertMatchingSession(100L, Instant.parse("2026-06-16T08:00:00Z"));
+		insertMatchingMember(1000L, 100L, 10L, null);
+		entityManager.flush();
+		entityManager.clear();
+
+		Optional<MatchingMember> result = repository.findCurrentActiveByUserId(1L);
+
+		assertThat(result).isEmpty();
+	}
+
+	private void insertUser(Long id) {
+		entityManager.createNativeQuery("""
+			INSERT INTO users (
+				id, email, nickname, temperature, level, is_github_login, created_at
+			) VALUES (
+				:id, :email, :nickname, 50, 1, false, CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("email", "user" + id + "@example.com")
+			.setParameter("nickname", "user" + id)
+			.executeUpdate();
+	}
+
+	private void insertProjectRequest(Long id, Long userId, String status) {
+		entityManager.createNativeQuery("""
+			INSERT INTO project_request (
+				id,
+				user_id,
+				role,
+				project_title,
+				project_description,
+				project_mvp,
+				status,
+				created_at
+			) VALUES (
+				:id,
+				:userId,
+				'BACKEND',
+				NULL,
+				NULL,
+				NULL,
+				:status,
+				CURRENT_TIMESTAMP
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("userId", userId)
+			.setParameter("status", status)
+			.executeUpdate();
+	}
+
+	private void insertMatchingSession(Long id, Instant deletedAt) {
+		entityManager.createNativeQuery("""
+			INSERT INTO matching_session (
+				id,
+				created_at,
+				deleted_at
+			) VALUES (
+				:id,
+				CURRENT_TIMESTAMP,
+				:deletedAt
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("deletedAt", deletedAt)
+			.executeUpdate();
+	}
+
+	private void insertMatchingMember(Long id, Long sessionId, Long projectRequestId, Instant deletedAt) {
+		entityManager.createNativeQuery("""
+			INSERT INTO matching_member (
+				id,
+				matching_session_id,
+				project_request_id,
+				is_accepted,
+				created_at,
+				deleted_at
+			) VALUES (
+				:id,
+				:sessionId,
+				:projectRequestId,
+				NULL,
+				CURRENT_TIMESTAMP,
+				:deletedAt
+			)
+			""")
+			.setParameter("id", id)
+			.setParameter("sessionId", sessionId)
+			.setParameter("projectRequestId", projectRequestId)
+			.setParameter("deletedAt", deletedAt)
+			.executeUpdate();
+	}
+}

--- a/src/test/java/team/po/feature/match/service/MatchServiceTest.java
+++ b/src/test/java/team/po/feature/match/service/MatchServiceTest.java
@@ -483,7 +483,7 @@ class MatchServiceTest {
 
 		when(matchingSessionRepository.findByIdWithLock(42L))
 			.thenReturn(Optional.of(session));
-		when(projectRequestRepository.findById(2L))  // ← 추가
+		when(projectRequestRepository.findByIdWithLock(2L))
 			.thenReturn(Optional.of(candidatePr));
 
 		// When
@@ -511,7 +511,7 @@ class MatchServiceTest {
 
 		when(matchingSessionRepository.findByIdWithLock(42L))
 			.thenReturn(Optional.of(session));
-		when(projectRequestRepository.findById(2L))  // ← 추가
+		when(projectRequestRepository.findByIdWithLock(2L))
 			.thenReturn(Optional.of(candidatePr));
 
 		// When


### PR DESCRIPTION
## 📌 Related Issue

Closes #98

## 🚀 Description

`/api/match/status`가 종료된 매칭 세션에 남은 stale `matching_member` 때문에 500을 반환하던 문제를 방지합니다.

- 현재 매칭 멤버 조회 조건에 활성 세션(`matching_session.deleted_at IS NULL`)과 `MATCHING` 요청 상태를 추가했습니다.
- 매칭 세션 생성/빈자리 충원 시 `ProjectRequest`를 pessimistic lock으로 재조회해 같은 요청이 동시에 여러 세션에 배정될 가능성을 줄였습니다.
- 종료된 세션에 남아 있는 stale `matching_member`를 soft-delete하고, 활성 `project_request_id` 중복을 막는 Flyway 마이그레이션을 추가했습니다.
- 과거 종료 세션의 멤버 행과 현재 매칭 행이 공존해도 현재 매칭 행만 조회하는 repository 회귀 테스트를 추가했습니다.

## 📢 Review Point

- `V26__fix_matching_member_active_uniqueness.sql`이 기존 운영 데이터에서 `matching_session.deleted_at IS NOT NULL`인 stale member만 정리하는지 확인해 주세요.
- `uq_matching_member_active_project_request`가 같은 `project_request`의 활성 `matching_member` 중복을 막으므로, 동시 매칭 시 중복 배정은 DB에서 한 번 더 차단됩니다.
- `findCurrentActiveByUserId`는 이제 `MATCHING` 요청만 조회하므로, 완료된 과거 요청이 남아 있어도 상태 조회 500으로 이어지지 않습니다.

## 📚 Etc (선택)

검증:

- `./gradlew test --tests 'team.po.feature.match.*'`
- `./gradlew test`
- `./gradlew build`
- `RUN_DB_TESTS=true ./gradlew clean build`

현재 로컬 작업트리에는 이번 PR 범위가 아닌 미추적 파일(`PasswordResetController`, `PasswordResetEmailRequest`, `.codex`, `logic-flow-bug-review.txt`)이 남아 있어 PR에는 포함하지 않았습니다.