### PR TITLE
팀 이름 수정 API 추가

### DIFF
--- a/src/main/java/team/po/feature/projectgroup/controller/ProjectGroupController.java
+++ b/src/main/java/team/po/feature/projectgroup/controller/ProjectGroupController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.po.common.auth.LoginUser;
+import team.po.exception.ApplicationException;
+import team.po.exception.ErrorCode;
 import team.po.feature.projectgroup.dto.GetMyProjectGroupResponse;
 import team.po.feature.projectgroup.dto.UpdateProjectGroupNameRequest;
 import team.po.feature.projectgroup.service.ProjectGroupService;
@@ -64,6 +66,10 @@ public class ProjectGroupController {
 		@PathVariable Long projectGroupId,
 		@Valid @RequestBody UpdateProjectGroupNameRequest request
 	) {
+		if (request == null) {
+			throw new ApplicationException(ErrorCode.INVALID_INPUT_FIELD, "요청 본문은 필수입니다.");
+		}
+
 		projectGroupService.updateProjectGroupName(projectGroupId, requester.getId(), request.projectName());
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/team/po/feature/projectgroup/controller/ProjectGroupController.java
+++ b/src/main/java/team/po/feature/projectgroup/controller/ProjectGroupController.java
@@ -64,7 +64,7 @@ public class ProjectGroupController {
 	public ResponseEntity<Void> updateProjectGroupName(
 		@Parameter(hidden = true) @LoginUser Users requester,
 		@PathVariable Long projectGroupId,
-		@Valid @RequestBody UpdateProjectGroupNameRequest request
+		@Valid @RequestBody(required = false) UpdateProjectGroupNameRequest request
 	) {
 		if (request == null) {
 			throw new ApplicationException(ErrorCode.INVALID_INPUT_FIELD, "요청 본문은 필수입니다.");

--- a/src/main/java/team/po/feature/projectgroup/controller/ProjectGroupController.java
+++ b/src/main/java/team/po/feature/projectgroup/controller/ProjectGroupController.java
@@ -5,14 +5,17 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import team.po.common.auth.LoginUser;
 import team.po.feature.projectgroup.dto.GetMyProjectGroupResponse;
+import team.po.feature.projectgroup.dto.UpdateProjectGroupNameRequest;
 import team.po.feature.projectgroup.service.ProjectGroupService;
 import team.po.feature.user.domain.Users;
 
@@ -51,6 +54,17 @@ public class ProjectGroupController {
 		@PathVariable Long targetUserId
 	) {
 		projectGroupService.revokeAdminPermission(projectGroupId, requester.getId(), targetUserId);
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "팀 스페이스 이름 수정 API")
+	@PatchMapping("/{projectGroupId}/name")
+	public ResponseEntity<Void> updateProjectGroupName(
+		@Parameter(hidden = true) @LoginUser Users requester,
+		@PathVariable Long projectGroupId,
+		@Valid @RequestBody UpdateProjectGroupNameRequest request
+	) {
+		projectGroupService.updateProjectGroupName(projectGroupId, requester.getId(), request.projectName());
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/team/po/feature/projectgroup/domain/ProjectGroup.java
+++ b/src/main/java/team/po/feature/projectgroup/domain/ProjectGroup.java
@@ -61,4 +61,8 @@ public class ProjectGroup {
 	public void finish() {
 		this.status = ProjectGroupStatus.FINISHED;
 	}
+
+	public void updateProjectName(String projectName) {
+		this.projectName = projectName;
+	}
 }

--- a/src/main/java/team/po/feature/projectgroup/dto/UpdateProjectGroupNameRequest.java
+++ b/src/main/java/team/po/feature/projectgroup/dto/UpdateProjectGroupNameRequest.java
@@ -1,0 +1,11 @@
+package team.po.feature.projectgroup.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateProjectGroupNameRequest(
+	@NotBlank(message = "팀 이름은 필수입니다.")
+	@Size(max = 255, message = "팀 이름은 255자 이하여야 합니다.")
+	String projectName
+) {
+}

--- a/src/main/java/team/po/feature/projectgroup/service/ProjectGroupService.java
+++ b/src/main/java/team/po/feature/projectgroup/service/ProjectGroupService.java
@@ -34,6 +34,7 @@ import team.po.feature.user.repository.UserRepository;
 @RequiredArgsConstructor
 public class ProjectGroupService {
 	private static final long REQUIRED_TEAM_MEMBER_COUNT = 4L;
+	private static final int PROJECT_NAME_MAX_LENGTH = 255;
 
 	private final ProjectGroupRepository projectGroupRepository;
 	private final ProjectGroupMemberRepository projectGroupMemberRepository;
@@ -150,6 +151,36 @@ public class ProjectGroupService {
 	}
 
 	@Transactional
+	public void updateProjectGroupName(Long projectGroupId, Long requesterUserId, String projectName) {
+		String trimmedProjectName = this.validateProjectName(projectName);
+		ProjectGroup projectGroup = projectGroupRepository.findByIdForUpdate(projectGroupId)
+			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_GROUP_NOT_FOUND));
+
+		ProjectGroupMember requesterMember = projectGroupMemberRepository
+			.findByProjectGroup_IdAndUser_Id(projectGroupId, requesterUserId)
+			.orElseThrow(() -> new ApplicationException(
+				ErrorCode.PROJECT_GROUP_ACCESS_DENIED,
+				"팀원만 팀 이름을 수정할 수 있습니다."
+			));
+
+		if (projectGroup.getStatus() == ProjectGroupStatus.FINISHED) {
+			throw new ApplicationException(
+				ErrorCode.PROJECT_GROUP_PERMISSION_DENIED,
+				"종료된 팀 스페이스에서는 팀 이름을 수정할 수 없습니다."
+			);
+		}
+
+		if (requesterMember.getGroupRole() != GroupRole.HOST) {
+			throw new ApplicationException(
+				ErrorCode.PROJECT_GROUP_PERMISSION_DENIED,
+				"방장만 팀 이름을 수정할 수 있습니다."
+			);
+		}
+
+		projectGroup.updateProjectName(trimmedProjectName);
+	}
+
+	@Transactional
 	public void finishProjectGroup(Long projectGroupId, Long requesterUserId) {
 		ProjectGroup projectGroup = projectGroupRepository.findByIdForUpdate(projectGroupId)
 			.orElseThrow(() -> new ApplicationException(ErrorCode.PROJECT_GROUP_NOT_FOUND));
@@ -196,6 +227,25 @@ public class ProjectGroupService {
 				"프로젝트 제목은 비어 있을 수 없습니다."
 			);
 		}
+	}
+
+	private String validateProjectName(String projectName) {
+		if (projectName == null || projectName.isBlank()) {
+			throw new ApplicationException(
+				ErrorCode.INVALID_PROJECT_GROUP_REQUEST,
+				"팀 이름은 비어 있을 수 없습니다."
+			);
+		}
+
+		String trimmedProjectName = projectName.trim();
+		if (trimmedProjectName.length() > PROJECT_NAME_MAX_LENGTH) {
+			throw new ApplicationException(
+				ErrorCode.INVALID_PROJECT_GROUP_REQUEST,
+				"팀 이름은 255자 이하여야 합니다."
+			);
+		}
+
+		return trimmedProjectName;
 	}
 
 	private void validateMembers(

--- a/src/test/java/team/po/feature/projectgroup/controller/ProjectGroupControllerTest.java
+++ b/src/test/java/team/po/feature/projectgroup/controller/ProjectGroupControllerTest.java
@@ -98,6 +98,16 @@ class ProjectGroupControllerTest {
 	}
 
 	@Test
+	void updateProjectGroupName_returnsBadRequest_whenRequestBodyIsNull() throws Exception {
+		mockMvc.perform(patch("/api/project-groups/{projectGroupId}/name", 10L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("null"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_FIELD.getCode()))
+			.andExpect(jsonPath("$.message").value("요청 본문은 필수입니다."));
+	}
+
+	@Test
 	void finishProjectGroup_returnsOk_whenMemberAgrees() throws Exception {
 		mockMvc.perform(patch("/api/project-groups/{projectGroupId}/finish", 10L))
 			.andExpect(status().isOk());

--- a/src/test/java/team/po/feature/projectgroup/controller/ProjectGroupControllerTest.java
+++ b/src/test/java/team/po/feature/projectgroup/controller/ProjectGroupControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -70,6 +71,30 @@ class ProjectGroupControllerTest {
 	@AfterEach
 	void tearDown() {
 		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	void updateProjectGroupName_returnsOk_whenRequestIsValid() throws Exception {
+		mockMvc.perform(patch("/api/project-groups/{projectGroupId}/name", 10L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"projectName":"New Team"}
+					"""))
+			.andExpect(status().isOk());
+
+		verify(projectGroupService).updateProjectGroupName(10L, 1L, "New Team");
+	}
+
+	@Test
+	void updateProjectGroupName_returnsBadRequest_whenNameIsBlank() throws Exception {
+		mockMvc.perform(patch("/api/project-groups/{projectGroupId}/name", 10L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+					{"projectName":" "}
+					"""))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_FIELD.getCode()))
+			.andExpect(jsonPath("$.fieldErrors.projectName").value("팀 이름은 필수입니다."));
 	}
 
 	@Test

--- a/src/test/java/team/po/feature/projectgroup/service/ProjectGroupServiceTest.java
+++ b/src/test/java/team/po/feature/projectgroup/service/ProjectGroupServiceTest.java
@@ -288,6 +288,55 @@ class ProjectGroupServiceTest {
 	}
 
 	@Test
+	void updateProjectGroupName_updatesName_whenRequesterIsHost() {
+		ProjectGroup projectGroup = ProjectGroup.builder()
+			.projectName("Teampo Alpha")
+			.projectTitle("주제 A")
+			.status(ProjectGroupStatus.ACTIVE)
+			.build();
+		ProjectGroupMember hostMember = new ProjectGroupMember(projectGroup, mockUser(1L), MemberRole.BACKEND,
+			GroupRole.HOST);
+
+		when(projectGroupRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(projectGroup));
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 1L))
+			.thenReturn(Optional.of(hostMember));
+
+		projectGroupService.updateProjectGroupName(10L, 1L, "  New Team  ");
+
+		assertThat(projectGroup.getProjectName()).isEqualTo("New Team");
+	}
+
+	@Test
+	void updateProjectGroupName_throwsForbidden_whenRequesterIsNotHost() {
+		ProjectGroup projectGroup = ProjectGroup.builder()
+			.projectName("Teampo Alpha")
+			.projectTitle("주제 A")
+			.status(ProjectGroupStatus.ACTIVE)
+			.build();
+		ProjectGroupMember member = new ProjectGroupMember(projectGroup, mockUser(2L), MemberRole.FRONTEND,
+			GroupRole.MEMBER);
+
+		when(projectGroupRepository.findByIdForUpdate(10L)).thenReturn(Optional.of(projectGroup));
+		when(projectGroupMemberRepository.findByProjectGroup_IdAndUser_Id(10L, 2L))
+			.thenReturn(Optional.of(member));
+
+		assertThatThrownBy(() -> projectGroupService.updateProjectGroupName(10L, 2L, "New Team"))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.PROJECT_GROUP_PERMISSION_DENIED.getCode());
+	}
+
+	@Test
+	void updateProjectGroupName_throwsBadRequest_whenNameIsBlank() {
+		assertThatThrownBy(() -> projectGroupService.updateProjectGroupName(10L, 1L, " "))
+			.isInstanceOf(ApplicationException.class)
+			.extracting("code")
+			.isEqualTo(ErrorCode.INVALID_PROJECT_GROUP_REQUEST.getCode());
+
+		verify(projectGroupRepository, never()).findByIdForUpdate(anyLong());
+	}
+
+	@Test
 	void finishProjectGroup_finishesProjectGroup_whenAllMembersAgree() {
 		ProjectGroup projectGroup = ProjectGroup.builder()
 			.projectName("Teampo Alpha")


### PR DESCRIPTION
Summary
- ProjectGroups에 팀 이름 수정 API를 추가했습니다.
- 방장 권한, 종료된 팀 스페이스 차단, 빈 값/255자 초과 검증을 적용했습니다.
- 컨트롤러와 서비스 단위 테스트를 추가했습니다.

Validation
- ./gradlew test: pass, staged patch만 적용한 clean worktree에서 실행

Closes #100